### PR TITLE
feature/339-ui-navigation-lock-user

### DIFF
--- a/service/ui/component/Nav.html
+++ b/service/ui/component/Nav.html
@@ -12,9 +12,11 @@
 				<li>
 					<a href="/profile">Profile</a>
 				</li>
+				{{#if signedInUser.department || signedInUser.profession || signedInUser.grade }}
 				<li>
 					<a href="/search">Search</a>
 				</li>
+				{{/if}}
 				<li>
                     <a href="/sign-out">Sign out</a>
 				</li>

--- a/service/ui/page/profile/edit.html
+++ b/service/ui/page/profile/edit.html
@@ -4,29 +4,35 @@
             <div class="column-two-thirds">
                 <h1 class="heading-large">Profile</h1>
 
-                {{#if identityServerFailed || validFields }}
-                {{validFields && validFields.department ? "form-group-error": ''}}
+                {{#if identityServerFailed || validFields || !signedInUser.department}}
 
-                <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-                    <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-                        Update failed
-                    </h2>
-                    <p>
-                        {{#if identityServerFailed}}
-                            Server error. Update failed, please try again or contact the <a href="mailto:feedback@cslearning.gov.uk">Civil Service Learning Team</a>
-                        {{else}}
-                            Form error. Fields cannot be empty.
 
+                    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+                        {{#if identityServerFailed || validFields }}
+                        <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+                            Update failed
+                        </h2>
                         {{/if}}
+                        <p>
+                            {{#if identityServerFailed}}
+                                Server error. Update failed, please try again or contact the <a href="mailto:feedback@cslearning.gov.uk">Civil Service Learning Team</a>
+                            {{elseif validFields}}
+                                Form error. Fields cannot be empty.
+                            {{/if}}
+                        </p>
+                        {{#if !signedInUser.department }}
+                        <p>
+                            To view learning opportunities, you must complete your profile.
+                        </p>
+                        {{/if}}
+                    </div>
 
-                    </p>
-                </div>
                 {{/if}}
 
                 <form method="post" class="push-bottom">
                     <div class="form-group">
                         <label class="form-label" for="userName">Email address</label>
-                        <input class="form-control" id="userName" name="userName" value="{{user.emailAddress}}" type="text" readonly="readonly">
+                        <input class="form-control" id="userName" name="userName" value="{{user.emailAddress || ''}}" type="text" readonly="readonly">
                     </div>
 
                     <div class="form-group {{validFields && !validFields.department ?  "form-group-error": ''}}">
@@ -34,7 +40,7 @@
                         {{#if validFields && !validFields.department}}
                         <span class="error-message">Department field cannot be empty.</span>
                         {{/if}}
-                        <input class="form-control" id="department" name="department" type="text" value="{{user.department}}">
+                        <input class="form-control" id="department" name="department" type="text" value="{{user.department || ''}}">
                     </div>
 
                     <div class="form-group {{validFields && !validFields.profession ? "form-group-error": ''}}">
@@ -42,7 +48,7 @@
                         {{#if validFields && !validFields.profession}}
                         <span class="error-message">Profession field cannot be empty.</span>
                         {{/if}}
-                        <input class="form-control" id="profession" name="profession" type="text" value="{{user.profession}}">
+                        <input class="form-control" id="profession" name="profession" type="text" value="{{user.profession || ''}}">
                     </div>
 
                     <div class="form-group {{validFields && !validFields.grade ? "form-group-error": ''}}">
@@ -50,7 +56,7 @@
                         {{#if validFields && !validFields.grade}}
                         <span class="error-message">Department field cannot be empty.</span>
                         {{/if}}
-                        <input class="form-control" id="grade" name="grade" type="text" value="{{user.grade}}">
+                        <input class="form-control" id="grade" name="grade" type="text" value="{{user.grade || ''}}">
                     </div>
 
                     <input type="submit" class="button" value="Continue">


### PR DESCRIPTION
At the moment, if a user's profile isn't complete, going to /search will redirect you to /profile with no message so it looks like a bug.

This PR includes:
* a message in the error boxes that the user cannot continue without completing their profile
* remove profile button from the nav (if the user tries to go to /search it will redirect to /profile)

