### PR TITLE
feature/348-implement-node-catalog-service

### DIFF
--- a/bin/gen-service-proto
+++ b/bin/gen-service-proto
@@ -1,0 +1,49 @@
+#! /usr/bin/env python
+
+import sys
+
+def error(msg):
+    print '!! ERROR: %s' % msg
+    sys.exit(1)
+
+args = sys.argv[1:]
+if not args:
+    print 'Usage: gen-service-proto [METHODS ...]'
+    sys.exit()
+
+messages = []
+methods = []
+
+for method in args:
+    method = method.strip()
+    if not method:
+        continue
+    if method[0] == method[0].upper():
+        error('The method name %r must start with a lowercase character' % method)
+    if not method[0].isalpha():
+        error('The method name %r must start with a character in the range a-z' % method)
+    msg = method[0].upper() + method[1:]
+    messages.append(msg + 'Request')
+    messages.append(msg + 'Response')
+    methods.append([method, msg])
+
+descriptor = [
+    'syntax = "proto3";',
+    '',
+    'service api {'
+]
+
+for (method, msg) in sorted(methods):
+    descriptor.append(
+        '   rpc %s(%sRequest) returns (%sResponse);' % (method, msg, msg)
+    )
+
+descriptor.append('}')
+descriptor.append('')
+
+for idx, msg in enumerate(sorted(messages)):
+    descriptor.append('message %s {' % msg)
+    descriptor.append('}')
+    descriptor.append('')
+
+print '\n'.join(descriptor)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: "3.4"
+services:
+  dgraph-server:
+    command: ["dgraph", "server", "--memory_mb", "2048", "--my", "dgraph-server:7080", "--zero", "dgraph-zero:5080"]
+    depends_on:
+      - dgraph-zero
+    image: dgraph/dgraph@sha256:435646c5fc42b7da3879203a6c1d8f246b4181843aed4df6e2afd9cdc11efa30
+    ports:
+      - 8080:8080
+      - 9080:9080
+    restart: on-failure
+  dgraph-viewer:
+    command: ["dgraph-ratel"]
+    depends_on:
+      - dgraph-server
+    image: dgraph/dgraph@sha256:435646c5fc42b7da3879203a6c1d8f246b4181843aed4df6e2afd9cdc11efa30
+    ports:
+      - 8081:8081
+  dgraph-zero:
+    command: ["dgraph", "zero", "--my", "dgraph-zero:5080", "--port_offset", "-2000"]
+    image: dgraph/dgraph@sha256:435646c5fc42b7da3879203a6c1d8f246b4181843aed4df6e2afd9cdc11efa30
+    ports:
+      - 5080:5080
+      - 6080:6080
+    restart: on-failure

--- a/service/catalog/package.json
+++ b/service/catalog/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "lpg-catalog-service",
+	"version": "0.0.1",
+	"scripts": {
+		"build": "../../bin/tsc",
+		"clean": "rm -rf dist",
+		"lint": "tslint --project tsconfig.json",
+		"postinstall": "test -e node_modules/ui || ln -s ../dist node_modules/ui",
+		"service": "node dist/catalog.js",
+		"watch": "../../bin/tsc --watch"
+	},
+	"dependencies": {
+		"dgraph-js": "1.0.1"
+	},
+	"devDependencies": {
+		"@types/node": "9.3.0",
+		"protobufjs": "6.8.4",
+		"tslint": "5.9.1",
+		"typescript": "2.6.2"
+	}
+}

--- a/service/catalog/service.proto
+++ b/service/catalog/service.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+service api {
+   rpc add(AddRequest) returns (AddResponse);
+   rpc search(SearchRequest) returns (SearchResponse);
+   rpc setSchema(SetSchemaRequest) returns (SetSchemaResponse);
+   rpc wipe(WipeRequest) returns (WipeResponse);
+}
+
+message AddRequest {
+    Entry entry = 1;
+}
+
+message AddResponse {
+}
+
+message Entry {
+    string tags = 1;
+    string title = 2;
+    string uid = 3;
+    string uri = 4;
+}
+
+message SearchRequest {
+    repeated string tags = 1;
+    int32 first = 2;
+    string after = 3;
+}
+
+message SearchResponse {
+    repeated Entry entries = 1;
+}
+
+message SetSchemaRequest {
+    string schema = 1;
+}
+
+message SetSchemaResponse {
+}
+
+message WipeRequest {
+}
+
+message WipeResponse {
+}

--- a/service/catalog/tsconfig.json
+++ b/service/catalog/tsconfig.json
@@ -1,0 +1,1 @@
+../../common/tsconfig.json

--- a/service/catalog/tslint.json
+++ b/service/catalog/tslint.json
@@ -1,0 +1,1 @@
+../../common/tslint.json

--- a/service/ui/package.json
+++ b/service/ui/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"compression": "1.7.1",
 		"config": "1.29.0",
+		"dgraph-js": "1.0.1",
 		"express": "4.16.2",
 		"express-session": "1.15.6",
 		"express-validator": "4.3.0",

--- a/service/ui/src/service/catalog/api.ts
+++ b/service/ui/src/service/catalog/api.ts
@@ -1,0 +1,16 @@
+export interface Entry {
+	tags?: string[]
+	title?: string
+	uid?: string
+	uri?: string
+}
+
+export interface SearchRequest {
+	tags?: string[]
+	first?: number
+	after?: string
+}
+
+export interface SearchResponse {
+	entries: Entry[]
+}

--- a/service/ui/src/service/catalog/index.ts
+++ b/service/ui/src/service/catalog/index.ts
@@ -1,0 +1,116 @@
+import * as dgraph from 'dgraph-js'
+import * as grpc from 'grpc'
+import * as api from 'ui/service/catalog/api'
+import * as elko from 'ui/service/elko'
+
+const {DGRAPH_ENDPOINT = 'localhost:9080'} = process.env
+
+// TODO(tav): Figure out how to make client requests respect deadlines.
+const client = new dgraph.DgraphClient(
+	new dgraph.DgraphClientStub(
+		DGRAPH_ENDPOINT,
+		grpc.credentials.createInsecure()
+	)
+)
+
+export async function add(ctx: elko.Context, {entry}: {entry: api.Entry}) {
+	const txn = client.newTxn()
+	try {
+		const mu = new dgraph.Mutation()
+		mu.setSetJson({
+			tags: entry.tags || [],
+			title: entry.title || '',
+			uri: entry.uri || '',
+		})
+		mu.setCommitNow(true)
+		const assigned = await txn.mutate(mu)
+		return assigned.getUidsMap().get('blank-0')
+	} finally {
+		await txn.discard()
+	}
+}
+
+export async function search(
+	ctx: elko.Context,
+	req: api.SearchRequest
+): Promise<api.SearchResponse> {
+	const map: Record<string, [number, number, api.Entry]> = {}
+	const results = []
+	if (!req.tags || !req.tags.length) {
+		return {entries: []}
+	}
+	for (const tag of req.tags) {
+		const query = `query all($tag: string) {
+			entries(func: eq(tags, $tag)) {
+				tags
+				title
+				uid
+				uri
+			}
+		}`
+		const qresp = await client.newTxn().queryWithVars(query, {$tag: tag})
+		const entries = qresp.getJson().entries
+		for (const entry of entries) {
+			let info = map[entry.uid]
+			if (info) {
+				info[0] += 1
+			} else {
+				info = [1, parseInt(entry.uid, 16), entry]
+				map[entry.uid] = info
+				results.push(info)
+			}
+		}
+	}
+	results.sort(
+		(a: [number, number, api.Entry], b: [number, number, api.Entry]) => {
+			if (b[0] > a[0]) {
+				return 1
+			} else if (b[0] < a[0]) {
+				return -1
+			}
+			if (b[1] > a[1]) {
+				return 1
+			} else if (b[1] < a[1]) {
+				return -1
+			}
+			return 0
+		}
+	)
+	const {after, first} = req
+	const resp: api.Entry[] = []
+	let count = 0
+	let include = true
+	if (after) {
+		include = false
+	}
+	for (const info of results) {
+		const entry = info[2]
+		if (include) {
+			resp.push(entry)
+		} else {
+			if (entry.uid === after) {
+				include = true
+			}
+			continue
+		}
+		if (first) {
+			count += 1
+			if (count === first) {
+				break
+			}
+		}
+	}
+	return {entries: resp}
+}
+
+export async function setSchema(ctx: elko.Context, {schema}: {schema: string}) {
+	const op = new dgraph.Operation()
+	op.setSchema(schema)
+	await client.alter(op)
+}
+
+export async function wipe(ctx: elko.Context) {
+	const op = new dgraph.Operation()
+	op.setDropAll(true)
+	await client.alter(op)
+}

--- a/service/ui/src/service/elko.ts
+++ b/service/ui/src/service/elko.ts
@@ -1,0 +1,6 @@
+// Create a fresh Context.
+export function context(): Context {
+	return new Context()
+}
+
+export class Context {}


### PR DESCRIPTION
This PR implements the `catalog` service as a library within the `ui` service that mimics the API that will be used down the line, e.g.

```js
const resp = await catalog.search(elko.context(), {
  first: 10,
  tags: ['alice', 'david', 'tav'],
})
```

A few things to note:

* The import path for the catalog service is currently `ui/service/catalog`. Once finished, it will probably be just `service/catalog`.

* Similarly, the import path for `elko` is currently `ui/service/elko`. Once finished, it will be just `elko`.

* I decided to throw Errors instead of returning a `(response, error)` tuple as it's easier to handle for the common case.

There is a fully sequenced example added in `server.ts` as `catalogDemo`. You need `dgraph` running in order to be able to run this demo. The easiest way to do that is by running docker compose within the repo.

If, like me, you prefer docker compose to use fresh containers every time, then run:

    docker-compose up --force-recreate
