### PR TITLE
chore/npm-util-scripts

### DIFF
--- a/bin/setup-dist
+++ b/bin/setup-dist
@@ -12,16 +12,26 @@ ln -s ../src/catalog
 ln -s ../src/locale
 
 mkdir management-ui
+mkdir management-ui/assets
 mkdir ui
+mkdir ui/assets
+
+
+cd "$dist/management-ui/assets"
+ln -s ../../src/management-ui/assets/js
+ln -s ../../src/management-ui/assets/img
 
 cd "$dist/management-ui"
 
-ln -s ../../src/management-ui/assets .
 ln -s ../../src/management-ui/component .
 ln -s ../../src/management-ui/page .
 
+cd "$dist/ui/assets"
+
+ln -s ../../../src/ui/assets/js .
+ln -s ../../../src/ui/assets/img .
+
 cd "$dist/ui"
 
-ln -s ../../src/ui/assets
 ln -s ../../src/ui/component
 ln -s ../../src/ui/page

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
 		"start:ui":
 			"cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
 		"watch": "./bin/tsc -w",
-		"watch-sass": "nodemon -e scss -x \"npm run sass:all\"",
+		"watch-sass-nodemon": "nodemon -e scss -x \"npm run sass:all\"",
+		"watch-sass:ui":
+			"node-sass -w -r src/ui/assets/styles -o dist/ui/assets/styles",
+		"watch-sass:management":
+			"node-sass -w -r src/management-ui/assets/styles -o dist/management-ui/assets/styles",
 		"dev:ui": "npm run watch & npm run watch-sass & npm run start:ui & wait",
 		"dev:management":
 			"npm run watch & npm run watch-sass & npm run start:management & wait"

--- a/package.json
+++ b/package.json
@@ -12,19 +12,17 @@
 			"node-sass src/management-ui/assets/styles/index.scss dist/management-ui/assets/styles/main.css",
 		"sass:ui":
 			"node-sass src/ui/assets/styles/main.scss dist/ui/assets/styles/main.css",
+		"sass:all": "npm run sass:management & npm run sass:ui",
 		"start:all": "npm run start:management & npm run start:ui",
 		"start:management":
 			"cd dist/management-ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/management-ui/server.js",
 		"start:ui":
 			"cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
 		"watch": "./bin/tsc -w",
-		"watchsass:ui":
-			"node-sass -w src/ui/assets/styles -o dist/ui/assets/styles",
-		"watchsass:management":
-			"node-sass -w src/management-ui/assets/styles -o dist/management-ui/assets/styles",
-		"dev:ui": "npm run watch & npm run watchsass:ui & npm run start:ui & wait",
+		"watch-sass": "nodemon -e scss -x \"npm run sass:all\"",
+		"dev:ui": "npm run watch & npm run watch-sass & npm run start:ui & wait",
 		"dev:management":
-			"npm run watch & npm run watchsass:management & npm run start:management & wait"
+			"npm run watch & npm run watch-sass & npm run start:management & wait"
 	},
 	"devDependencies": {
 		"@types/compression": "0.0.35",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,22 @@
 		"nuke": "rm -rf dist node_modules",
 		"postinstall": "./bin/setup-dist",
 		"sass:management":
-			"node-sass src/management-ui/assets/styles/index.scss src/management-ui/assets/styles/main.css",
+			"node-sass src/management-ui/assets/styles/index.scss dist/management-ui/assets/styles/main.css",
 		"sass:ui":
-			"node-sass src/ui/assets/styles/main.scss src/ui/assets/styles/main.css",
+			"node-sass src/ui/assets/styles/main.scss dist/ui/assets/styles/main.css",
 		"start:all": "npm run start:management & npm run start:ui",
 		"start:management":
 			"cd dist/management-ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/management-ui/server.js",
 		"start:ui":
 			"cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
-		"watch": "./bin/tsc -w"
+		"watch": "./bin/tsc -w",
+		"watchsass:ui":
+			"node-sass -w src/ui/assets/styles -o dist/ui/assets/styles",
+		"watchsass:management":
+			"node-sass -w src/management-ui/assets/styles -o dist/management-ui/assets/styles",
+		"dev:ui": "npm run watch & npm run watchsass:ui & npm run start:ui & wait",
+		"dev:management":
+			"npm run watch & npm run watchsass:management & npm run start:management & wait"
 	},
 	"devDependencies": {
 		"@types/compression": "0.0.35",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
 			"node-sass -w -r src/ui/assets/styles -o dist/ui/assets/styles",
 		"watch-sass:management":
 			"node-sass -w -r src/management-ui/assets/styles -o dist/management-ui/assets/styles",
-		"dev:ui": "npm run watch & npm run watch-sass & npm run start:ui & wait",
+		"dev:ui": "npm run watch & npm run watch-sass:ui & npm run start:ui & wait",
 		"dev:management":
-			"npm run watch & npm run watch-sass & npm run start:management & wait"
+			"npm run watch & npm run watch-sass:management & npm run start:management & wait"
 	},
 	"devDependencies": {
 		"@types/compression": "0.0.35",


### PR DESCRIPTION
**please do not merge until decision made regarding nodemon vs node-sass -w**

PR includes:
* writing src/**/*.scss to dist/
* change setup-dist so it only symlinks js, img (not assets/styles)
* watch-sass script using nodemon
* watch-sass scripts using node-sass

which way of watching sass should we use? 