### PR TITLE
Feature/470 learners can interact with their learning plan

### DIFF
--- a/src/ui/component/Learning.html
+++ b/src/ui/component/Learning.html
@@ -34,12 +34,17 @@
 
     </div>
     <div class="resource__duration">
-        <span>{{course.type === ('elearning' || 'face-to-face') ? '' : course.type + ', '}}{{course.duration}}</span>
+        <span>
+        {{course.type === ('elearning' || 'face-to-face') ? '' : i18n(course.type) + (course.duration ? ', ' : '')}}
+        {{course.duration}}
+        </span>
     </div>
     <div class="resource__status">
-        <span class="badge badge--info badge--smaller">{{i18n(course.state || 'not started')}}</span>
+        {{#if course.state }}
+        <span class="badge badge--info badge--smaller">{{i18n(course.state)}}</span>
+        {{/if}}
         {{#if course.requiredBy && course.type !== ('elearning' || 'face-to-face') }}
-            <span class="meta">21 Aug 2018</span>
+            <span class="meta">{{formatDate(course.requiredBy)}}</span>
         {{/if}}
     </div>
 </div>

--- a/src/ui/component/LearningRecordTable.html
+++ b/src/ui/component/LearningRecordTable.html
@@ -1,0 +1,21 @@
+<table class="u-space-b30">
+    <thead>
+        <tr>
+            <th class="table--fix-first">Course title</th>
+            <th>Type</th>
+            <th>Duration</th>
+            <th>Completion date</th>
+
+        </tr>
+   </thead>
+    <tbody>
+    {{#each courses as course}}
+        <tr>
+            <td><a href="/courses/{{course.uid}}">{{course.title}} </a></td>
+            <td>{{i18n(course.type)}}</td>
+            <td>{{course.duration ? course.duration : '-'}}</td>
+            <td>{{formatDate(course.completionDate)}}</td>
+        </tr>
+    {{/each}}
+    </tbody>
+</table>

--- a/src/ui/page/home.html
+++ b/src/ui/page/home.html
@@ -1,8 +1,8 @@
 <Page title="overview">
-    <div class="container">
+    <div class="container container--main">
         <div class="grid-row">
             <div class="column-full">
-
+                <h1 class="heading-large">Your learning</h1>
                 <h2 class="heading-medium heading heading--medium heading--red-top">Required learning</h2>
 
                 {{#if requiredLearning.length}}
@@ -23,19 +23,12 @@
 
                 {{#if plannedLearning.length}}
                 <ul class="resource__list">
-                    {{#each plannedLearning.slice(0,3) as course}}
+                    {{#each plannedLearning as course}}
                     <li class="resource">
                         <Learning :course />
                     </li>
                     {{/each}}
                 </ul>
-                {{#if plannedLearning.length > 3 }}
-                <p class="u-space-t30">
-                    <a href="#">
-                        See more learning on learning plan
-                    </a>
-                </p>
-                {{/if}}
                 {{else}}
                 <p>You don't have any planned learning yet.</p>
                 {{/if}}

--- a/src/ui/page/learning-record/index.html
+++ b/src/ui/page/learning-record/index.html
@@ -3,65 +3,24 @@
         <div class="grid-row">
             <div class="column-full">
                 <h1 class="heading-large">Learning record</h1>
-                        <h2 class="heading heading--medium heading--red-top heading-medium">
-                          Required learning
-                        </h2>
-                        {{#if completedRequiredLearning.length}}
-
-                            <table class="u-space-b30">
-                                <thead>
-                                    <tr>
-                                        <th class="table--fix-first">Course title</th>
-                                        <th>Type</th>
-                                        <th>Duration</th>
-                                        <th>Completion date</th>
-
-                                    </tr>
-                               </thead>
-                                <tbody>
-                                {{#each completedRequiredLearning as course}}
-                                    <tr>
-                                        <td><a href="/courses/{{course.uid}}">{{course.title}} </a></td>
-                                        <td>{{course.type}}</td>
-                                        <td>{{course.duration ? course.duration : '-'}}</td>
-                                        <td>{{formatDate(course.completionDate)}}</td>
-                                    </tr>
-                                {{/each}}
-                                </tbody>
-                           </table>
-
-
+                    <h2 class="heading heading--medium heading--red-top heading-medium">
+                      Required learning
+                    </h2>
+                    {{#if completedRequiredLearning.length}}
+                        <LearningRecordTable courses={{completedRequiredLearning}}/>
                         <p>You have completed {{completedRequiredLearning.length}} out of {{requiredLearningTotal}} required learning courses.</p>
                     {{else}}
                         <p>You haven't completed any courses yet!</p>
                     {{/if}}
-                    {{#if completedRequiredLearning.length}}
-                        <h2 class="heading heading--medium heading--red-top heading-medium">
-                          Other learning
-                        </h2>
-                        <table class="u-space-b30">
-                            <thead>
-                                <tr>
-                                    <th class="table--fix-first">Course title</th>
-                                    <th>Type</th>
-                                    <th>Duration</th>
-                                    <th>Completion date</th>
-                                </tr>
-                           </thead>
-                            <tbody>
-                            {{#each courses as course}}
-                                <tr>
-                                    <td><a href="/courses/{{course.uid}}">{{course.title}} </a></td>
-                                    <td>{{course.type}}</td>
-                                    <td>{{course.duration ? course.duration : '-'}}</td>
-                                    <td>{{formatDate(course.completionDate)}}</td>
-                                </tr>
-                            {{/each}}
-                            </tbody>
-                       </table>
-                   {{else}}
+
+                    <h2 class="heading heading--medium heading--red-top heading-medium">
+                      Other learning
+                    </h2>
+                    {{#if courses.length}}
+                       <LearningRecordTable courses={{courses}}/>
+                    {{else}}
                    <p>You haven't completed any courses yet!</p>
-                {{/if}}
+                    {{/if}}
 
 
 


### PR DESCRIPTION
**PR includes:**

Changes for https://trello.com/c/eWhOjvPh/470-learners-can-interact-with-their-learning-plan
and https://trello.com/c/U80OQiI3/486-learners-can-see-their-learning-record. The bulk of these changes were made in #122, the trello cards were just split up.

*The 'learning plan' page is now just home, so it's removed from nav for now although there's some UR to see if its safe to remove the learning plan page completely.
* There's no longer a 3-course limit on the homepage because of this. 
* LearningRecordTable.html component for DRY-ness
* i18n for course.types 


 

