### PR TITLE
bug/545-mobile-view-home-page-learning-plan-missing-red-line-separator

### DIFF
--- a/src/ui/assets/styles/common/_global.scss
+++ b/src/ui/assets/styles/common/_global.scss
@@ -1,3 +1,10 @@
+hr.clear {
+	clear: both;
+	display: block;
+	height: 0;
+	visibility: hidden;
+}
+
 .column-one-sixth {
 	@include grid-column( 1/6 );
 }

--- a/src/ui/component/Nav.html
+++ b/src/ui/component/Nav.html
@@ -5,7 +5,7 @@
             <a href="/home">Home</a>
         </li>
         <li>
-            <a href="/suggested-for-you">{{i18n('suggestions_page_title')}}</a>
+            <a href="/suggestions-for-you">{{i18n('suggestions_page_title')}}</a>
         </li>
         <li>
             <a href="/learning-record">Learning record</a>

--- a/src/ui/component/Tile.html
+++ b/src/ui/component/Tile.html
@@ -17,10 +17,10 @@
 		{{course.shortDescription}}
 	</p>
 	<p class="tile__actions">
-		<a href="/suggested-for-you/add/{{course.id}}?ref=home">
+		<a href="/suggestions-for-you/add/{{course.id}}?ref=home">
 			Add to learning plan
 		</a>
-		<a href="/suggested-for-you/remove/{{course.id}}?ref=home">
+		<a href="/suggestions-for-you/remove/{{course.id}}?ref=home">
 			Remove
 			<span class="visuallyhidden">from suggested learning list</span>
 		</a>

--- a/src/ui/controllers/suggestion.ts
+++ b/src/ui/controllers/suggestion.ts
@@ -17,7 +17,7 @@ function findCourseByUID(courses: model.Course[], id: string) {
 
 export async function addToPlan(ireq: express.Request, res: express.Response) {
 	const req = ireq as extended.CourseRequest
-	const ref = req.query.ref === 'home' ? '/' : '/suggested-for-you'
+	const ref = req.query.ref === 'home' ? '/' : '/suggestions-for-you'
 	const course = req.course
 	let module
 	if (course.modules.length === 1) {
@@ -33,12 +33,12 @@ export async function addToPlan(ireq: express.Request, res: express.Response) {
 	}
 }
 
-export async function removeFromSuggested(
+export async function removeFromSuggestions(
 	ireq: express.Request,
 	res: express.Response
 ) {
 	const req = ireq as extended.CourseRequest
-	const ref = req.query.ref === 'home' ? '/' : '/suggested-for-you'
+	const ref = req.query.ref === 'home' ? '/' : '/suggestions-for-you'
 	const course = req.course
 	let module
 	if (course.modules.length === 1) {
@@ -54,7 +54,7 @@ export async function removeFromSuggested(
 	}
 }
 
-export async function suggestedForYou(
+export async function suggestionsForYou(
 	req: express.Request,
 	res: express.Response
 ) {

--- a/src/ui/page/home.html
+++ b/src/ui/page/home.html
@@ -3,7 +3,7 @@
         <div class="grid-row">
             <div class="column-full">
                 <h1 class="heading-large">{{i18n('home_page_title')}}</h1>
-                <h2 class="heading-medium heading heading--medium heading--red-top lpg-required-learning">
+                <h2 class="heading-medium heading heading--red-top lpg-required-learning">
                     {{i18n('required_section_title')}}
                 </h2>
 
@@ -19,8 +19,9 @@
                 <p>{{i18n('required_learning_done')}}</p>
                 {{/if}}
             </div>
+            <hr class="clear">
             <div class="column-full">
-                <h2 class="heading-medium heading heading--medium heading--red-top lpg-other-learning">
+                <h2 class="heading-medium heading heading--red-top lpg-other-learning">
                     {{i18n('other_section_title')}}
                 </h2>
                 {{#if plannedLearning.length}}
@@ -62,7 +63,7 @@
             </div>
             <div class="grid-row">
                 <div class="column-full">
-                    <p><a href="/suggested-for-you">{{i18n('home_page_suggestions_link')}}</a></p>
+                    <p><a href="/suggestions-for-you">{{i18n('home_page_suggestions_link')}}</a></p>
                 </div>
             </div>
 

--- a/src/ui/page/suggested.html
+++ b/src/ui/page/suggested.html
@@ -15,10 +15,10 @@
                             <td>{{ i18n(course.getType()) }}</td>
                             <td>{{ course.shortDescription }}</td>
                             <td>
-                                <a class="button" href="/suggested-for-you/add/{{course.id}}">Add</a>
+                                <a class="button" href="/suggestions-for-you/add/{{course.id}}">Add</a>
                             </td>
                             <td>
-                                <a class="button" href="/suggested-for-you/remove/{{course.id}}/">Remove</a>
+                                <a class="button" href="/suggestions-for-you/remove/{{course.id}}/">Remove</a>
                             </td>
                         </tr>
                         {{/each}}

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -105,11 +105,11 @@ app.get('/learning-record', learningRecordController.display)
 app.get('/learning-record/:courseId', learningRecordController.courseResult)
 
 app.get('/search', searchController.search)
-app.get('/suggested-for-you', suggestionController.suggestedForYou)
-app.get('/suggested-for-you/add/:courseId', suggestionController.addToPlan)
+app.get('/suggestions-for-you', suggestionController.suggestionsForYou)
+app.get('/suggestions-for-you/add/:courseId', suggestionController.addToPlan)
 app.get(
-	'/suggested-for-you/remove/:courseId',
-	suggestionController.removeFromSuggested
+	'/suggestions-for-you/remove/:courseId',
+	suggestionController.removeFromSuggestions
 )
 
 app.get('/home', homeController.home)

--- a/test/headless/src/page/globals.ts
+++ b/test/headless/src/page/globals.ts
@@ -10,7 +10,7 @@ export const selectors: Record<string, string> = {
 	learningRecordMenuButton: 'a[href="/learning-record"]',
 	searchMenuButton: 'a[href="/search"]',
 	signoutMenuButton: 'a[href="/sign-out"]',
-	suggestedMenuButton: 'a[href="suggested-for-you"]',
+	suggestionsMenuButton: 'a[href="suggestions-for-you"]',
 }
 
 export async function completeFeedback(page: puppeteer.Page) {

--- a/test/headless/src/test/feedback.ts
+++ b/test/headless/src/test/feedback.ts
@@ -85,8 +85,8 @@ describe('feedback form functionality', () => {
 		).toBe(true)
 	})
 
-	it('Should display feedback link on suggested for you page', async () => {
-		await page.goto(config.BASE_URL + '/suggested-for-you')
+	it('Should display feedback link on suggestions for you page', async () => {
+		await page.goto(config.BASE_URL + '/suggestions-for-you')
 		await page.waitForSelector(selectors.feedbackPrompt)
 		expect(
 			await helper.checkElementIsPresent(selectors.feedbackPrompt, page)


### PR DESCRIPTION
This PR fixes both:

* [Mobile view (home page) learning plan missing red line separator](https://trello.com/c/Eq7MSqsk/545-bug-mobile-view-home-page-learning-plan-missing-red-line-separator)
* [Change /suggested-for-you url to /suggestions-for-you](https://trello.com/c/13eOwUHd/544-bug-change-suggested-for-you-url-to-suggestions-for-you)