### PR TITLE
Feature/529 set up user roles for mgmt ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,30 +5,23 @@
 		"build": "npm run compile && npm run sass:management && npm run sass:ui",
 		"clean": "./bin/setup-dist",
 		"compile": "./bin/tsc",
-		"dev:management":
-			"npm run watch & npm run watch-sass:management & npm run start:management & wait",
+		"dev:management": "npm run watch & npm run watch-sass:management & npm run start:management & wait",
 		"dev:ui": "npm run watch & npm run watch-sass:ui & npm run start:ui & wait",
 		"lint": "tslint --project tsconfig.json",
 		"lint:headless": "tslint --project test/headless/tsconfig.json",
 		"nuke": "rm -rf dist node_modules",
 		"postinstall": "./bin/setup-dist",
 		"sass:all": "npm run sass:management & npm run sass:ui",
-		"sass:management":
-			"node-sass src/management-ui/assets/styles/index.scss dist/management-ui/assets/styles/main.css",
-		"sass:ui":
-			"node-sass src/ui/assets/styles/main.scss dist/ui/assets/styles/main.css",
+		"sass:management": "node-sass src/management-ui/assets/styles/index.scss dist/management-ui/assets/styles/main.css",
+		"sass:ui": "node-sass src/ui/assets/styles/main.scss dist/ui/assets/styles/main.css",
 		"start:all": "npm run start:management & npm run start:ui",
-		"start:management":
-			"cd dist/management-ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/management-ui/server.js",
-		"start:ui":
-			"cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
+		"start:management": "cd dist/management-ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/management-ui/server.js",
+		"start:ui": "cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
 		"test": "NODE_ICU_DATA=node_modules/full-icu jest",
 		"watch": "./bin/tsc -w",
 		"watch-sass-nodemon": "nodemon -e scss -x \"npm run sass:all\"",
-		"watch-sass:ui":
-			"node-sass -w -r src/ui/assets/styles -o dist/ui/assets/styles",
-		"watch-sass:management":
-			"node-sass -w -r src/management-ui/assets/styles -o dist/management-ui/assets/styles"
+		"watch-sass:ui": "node-sass -w -r src/ui/assets/styles -o dist/ui/assets/styles",
+		"watch-sass:management": "node-sass -w -r src/management-ui/assets/styles -o dist/management-ui/assets/styles"
 	},
 	"devDependencies": {
 		"@types/compression": "0.0.35",

--- a/src/lib/config/passport.ts
+++ b/src/lib/config/passport.ts
@@ -48,6 +48,7 @@ export function configure(
 					nameID: profile.nameID,
 					nameIDFormat: profile.nameIDFormat,
 					profession: profile['http://wso2.org/claims/profession'],
+					roles: profile['http://wso2.org/claims/role'],
 					sessionIndex: profile.sessionIndex,
 				}),
 				{}

--- a/src/lib/config/passport.ts
+++ b/src/lib/config/passport.ts
@@ -11,7 +11,8 @@ function createUser(data: any) {
 		data.emailAddress,
 		data.nameID,
 		data.nameIDFormat,
-		data.sessionIndex
+		data.sessionIndex,
+		data.roles
 	)
 	user.department = data.department
 	user.profession = data.profession
@@ -102,6 +103,19 @@ export function isAuthenticated(
 	session.save(() => {
 		res.redirect('/authenticate')
 	})
+}
+
+export function hasRole(role: string) {
+	return (
+		req: express.Request,
+		res: express.Response,
+		next: express.NextFunction
+	) => {
+		if (req.user && req.user.hasRole(role)) {
+			return next()
+		}
+		res.sendStatus(401)
+	}
 }
 
 export function logout(req: express.Request, res: express.Response) {

--- a/src/lib/model.test.ts
+++ b/src/lib/model.test.ts
@@ -18,7 +18,7 @@ describe('Should test User roles logic', () => {
 		expect(user.hasRole('learner')).toBe(true)
 	})
 
-	it('User have role if was created with it and other roles', () => {
+	it('User should have role if was created with it and other roles', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',

--- a/src/lib/model.test.ts
+++ b/src/lib/model.test.ts
@@ -1,0 +1,89 @@
+import * as model from 'lib/model'
+
+describe('Should test User roles logic', () => {
+	it('User should have role if it was created with it', () => {
+		const user = new model.User(
+			'id123',
+			'test@example.com',
+			'test@example.com',
+			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+			'session123',
+			['learner']
+		)
+		user.department = 'commercial'
+		user.profession = 'co'
+		user.givenName = 'Test'
+		user.grade = 'Test'
+
+		expect(user.hasRole('learner')).toBe(true)
+	})
+
+	it('User have role if was created with it and other roles', () => {
+		const user = new model.User(
+			'id123',
+			'test@example.com',
+			'test@example.com',
+			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+			'session123',
+			['learner', 'management', 'other']
+		)
+		user.department = 'commercial'
+		user.profession = 'co'
+		user.givenName = 'Test'
+		user.grade = 'Test'
+
+		expect(user.hasRole('learner')).toBe(true)
+	})
+
+	it('User should not have role if it was created without it', () => {
+		const user = new model.User(
+			'id123',
+			'test@example.com',
+			'test@example.com',
+			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+			'session123',
+			['management']
+		)
+		user.department = 'commercial'
+		user.profession = 'co'
+		user.givenName = 'Test'
+		user.grade = 'Test'
+
+		expect(user.hasRole('learner')).toBe(false)
+	})
+
+	it('User should not have learner or management role if was created with no roles', () => {
+		const user = new model.User(
+			'id123',
+			'test@example.com',
+			'test@example.com',
+			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+			'session123',
+			[]
+		)
+		user.department = 'commercial'
+		user.profession = 'co'
+		user.givenName = 'Test'
+		user.grade = 'Test'
+
+		expect(user.hasRole('learner')).toBe(false)
+		expect(user.hasRole('management')).toBe(false)
+	})
+
+	it('User should not have learner or management role if was created with role in upper case', () => {
+		const user = new model.User(
+			'id123',
+			'test@example.com',
+			'test@example.com',
+			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+			'session123',
+			['Learner']
+		)
+		user.department = 'commercial'
+		user.profession = 'co'
+		user.givenName = 'Test'
+		user.grade = 'Test'
+
+		expect(user.hasRole('learner')).toBe(false)
+	})
+})

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -337,6 +337,7 @@ export class User {
 	readonly nameID: string
 	readonly nameIDFormat: string
 	readonly sessionIndex: string
+	readonly roles: string[]
 
 	department: string
 	profession: string
@@ -348,16 +349,26 @@ export class User {
 		emailAddress: string,
 		nameID: string,
 		nameIDFormat: string,
-		sessionIndex: string
+		sessionIndex: string,
+		roles: string[]
 	) {
 		this.id = id
 		this.emailAddress = emailAddress
 		this.nameID = nameID
 		this.nameIDFormat = nameIDFormat
 		this.sessionIndex = sessionIndex
+		this.roles = roles
 	}
 
 	hasCompleteProfile() {
-		return this.department && this.profession && this.grade
+		return this.department && this.profession && this.grade§2
+	}
+
+	hasRole(role: string) {
+		if (this.roles.indexOf(role) > -1) {
+			return true
+		} else {
+			return false
+		}
 	}
 }

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -361,11 +361,11 @@ export class User {
 	}
 
 	hasCompleteProfile() {
-		return this.department && this.profession && this.grade§2
+		return this.department && this.profession && this.grade
 	}
 
 	hasRole(role: string) {
-		if (this.roles.indexOf(role) > -1) {
+		if (this.roles && this.roles.indexOf(role) > -1) {
 			return true
 		} else {
 			return false

--- a/src/management-ui/server.ts
+++ b/src/management-ui/server.ts
@@ -65,6 +65,8 @@ passport.configure('lpg-management-ui', config.AUTHENTICATION.serviceUrl, app)
 i18n.configure(app)
 
 app.use(passport.isAuthenticated)
+app.use(passport.hasRole('management'))
+
 app.get('/sign-in', loginController.signIn)
 app.get('/sign-out', loginController.signOut)
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -73,6 +73,7 @@ app.get('/reset-password', userController.resetPassword)
 app.post('/feedback.record', feedbackController.record)
 
 app.use(passport.isAuthenticated)
+app.use(passport.hasRole('learner'))
 
 app.get('/api/lrs.record', learningRecordController.record)
 


### PR DESCRIPTION
**Overview:**
- https://trello.com/c/rA6cBNia/529-set-up-user-roles-for-management-and-ui.
- Setting up roles for management and learner users to authenticate login to app.
- A user will need the learner role to log into the UI.
- A user will need the management role to log into the Management-UI.
- Without appropriate role, user will receive 401 response.
- Changes coincide with PR on `lpg-wso2` (https://github.com/Civil-Service-Human-Resources/lpg-wso2-is/pull/8)

**Changes:**
- Adding roles attribute to User model.
- Get the role attribute from WSO2 response on authenticate and use this with the `createUser` constructor.
- Adding `hasRoles()` checker to `server.ts` to authenticate user, depending on if they have the appropriate role.

**Testing:**
- To test manually, you will have to run the updated version of wso2 locally to pick up new claim and user changes. Open the WSO2 console and observe roles for a given user. Add/remove roles as necessary and then log in to app to observe expected behaviour.
- Unit testing new `hasRole()` function in `model.ts`.

**Next steps:**
- Need to create a 401 unauth page in future, because currently it just redirects user to a blank page with  the word`UNAUTHORIZED`. There is no navigation to get user back to log in screen. The user would have to manually hit the /sign-out url to do anything.