### PR TITLE
bug/642-580

### DIFF
--- a/src/lib/datetime.test.ts
+++ b/src/lib/datetime.test.ts
@@ -2,22 +2,24 @@ import * as datetime from 'lib/datetime'
 
 describe('Should return formatted the date', () => {
 	it('Should return a formatted date', () => {
-		expect(datetime.formatDate(new Date(2018, 0, 1))).toBe('01/01/2018')
-		expect(datetime.formatDate(new Date(2018, 5, 1))).toBe('01/06/2018')
-		expect(datetime.formatDate(new Date(2018, 11, 1))).toBe('01/12/2018')
+		expect(datetime.formatDate(new Date(2018, 0, 1))).toBe('01 Jan 2018')
+		expect(datetime.formatDate(new Date(2018, 5, 1))).toBe('01 Jun 2018')
+		expect(datetime.formatDate(new Date(2018, 11, 1))).toBe('01 Dec 2018')
 	})
 
 	it('Should return formated date and time', () => {
-		expect(datetime.formatTime(new Date(2018, 0, 1))).toBe('01/01/2018, 00:00')
-		expect(datetime.formatTime(new Date(2018, 11, 1))).toBe('01/12/2018, 00:00')
+		expect(datetime.formatTime(new Date(2018, 0, 1))).toBe('01 Jan 2018, 00:00')
+		expect(datetime.formatTime(new Date(2018, 11, 1))).toBe(
+			'01 Dec 2018, 00:00'
+		)
 		expect(datetime.formatTime(new Date(2018, 11, 1, 12, 0, 0))).toBe(
-			'01/12/2018, 12:00'
+			'01 Dec 2018, 12:00'
 		)
 		expect(datetime.formatTime(new Date(2018, 11, 1, 11, 59, 59))).toBe(
-			'01/12/2018, 11:59'
+			'01 Dec 2018, 11:59'
 		)
 		expect(datetime.formatTime(new Date(2018, 11, 1, 23, 59, 59))).toBe(
-			'01/12/2018, 23:59'
+			'01 Dec 2018, 23:59'
 		)
 	})
 

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,6 +1,6 @@
 const dateFormat = new Intl.DateTimeFormat('en-GB', {
 	day: '2-digit',
-	month: '2-digit',
+	month: 'short',
 	timeZone: 'Europe/London',
 	year: 'numeric',
 })
@@ -16,7 +16,7 @@ const timeFormat = new Intl.DateTimeFormat('en-GB', {
 	day: '2-digit',
 	hour: 'numeric',
 	minute: '2-digit',
-	month: '2-digit',
+	month: 'short',
 	timeZone: 'Europe/London',
 	year: 'numeric',
 })

--- a/src/ui/assets/styles/components/_booking.scss
+++ b/src/ui/assets/styles/components/_booking.scss
@@ -90,13 +90,16 @@
 }
 
 .cancel {
+	@include e(list) {
+		float: left;
+		width: 100%;
+	}
 	@include e(return) {
 		float: right;
 	}
 	@include e(item) {
-		@include m(key) {
-			width: 50%;
-			display: inline-block;
-		}
+		width: 50%;
+		display: inline-block;
+		float: left;
 	}
 }

--- a/src/ui/page/booking/cancel-booking.html
+++ b/src/ui/page/booking/cancel-booking.html
@@ -21,10 +21,10 @@
                 <h3 class="heading-small">{{signedInUser.givenName}}</h3>
                 <ul class="cancel__list push-bottom">
                     <li>
-                        <span class="cancel__item--key">Requested Course:</span> <span class="bold-small">{{module.title || course.title}}</span>
+                        <span class="cancel__item">Requested Course:</span> <span class="bold-small cancel__item">{{module.title || course.title}}</span>
                     </li>
                     <li>
-                        <span class="cancel__item--key">Requested Date:</span> <span class="bold-small">{{formatDate(event.date)}}</span>
+                        <span class="cancel__item">Requested Date:</span> <span class="bold-small cancel__item">{{formatDate(event.date)}}</span>
                     </li>
                 </ul>
                 <form method="post" class="push-bottom">


### PR DESCRIPTION
PR includes:
* dateFormat uses "month: short" which is GDS standard [#580](https://trello.com/c/stfkRoPf/580-update-duration-formatting-to-correct-content-style)
* fix cancel booking columns  [#642](https://trello.com/c/NAyOoesy/642-bug-course-titles-are-running-onto-two-lines-when-booking-can-it-be-a-single-line-or-have-improved-spacing-one-line-under-anothe)