### PR TITLE
Feature/639 search pagination

### DIFF
--- a/src/lib/service/catalog/index.ts
+++ b/src/lib/service/catalog/index.ts
@@ -43,9 +43,10 @@ export async function postFeedback(feedback: model.Feedback) {
 	}
 }
 
-export async function search(query: string): Promise<api.SearchResults> {
+export async function search(query: string, page: number, size: number): Promise<api.SearchResults> {
 	try {
-		const response = await http.get(`/search?query=${query}`)
+		// const response = await http.get(`/search?query=${query}`)
+		const response = await http.get(`/search?query=${query}&page=${page}&size=${size}`)
 		return convert(response.data) as api.SearchResults
 	} catch (e) {
 		if (e.response.status === 400) {

--- a/src/lib/service/catalog/index.ts
+++ b/src/lib/service/catalog/index.ts
@@ -45,7 +45,6 @@ export async function postFeedback(feedback: model.Feedback) {
 
 export async function search(query: string, page: number, size: number): Promise<api.SearchResults> {
 	try {
-		// const response = await http.get(`/search?query=${query}`)
 		const response = await http.get(`/search?query=${query}&page=${page}&size=${size}`)
 		return convert(response.data) as api.SearchResults
 	} catch (e) {

--- a/src/lib/service/catalog/index.ts
+++ b/src/lib/service/catalog/index.ts
@@ -43,9 +43,15 @@ export async function postFeedback(feedback: model.Feedback) {
 	}
 }
 
-export async function search(query: string, page: number, size: number): Promise<api.SearchResults> {
+export async function search(
+	query: string,
+	page: number,
+	size: number
+): Promise<api.SearchResults> {
 	try {
-		const response = await http.get(`/search?query=${query}&page=${page}&size=${size}`)
+		const response = await http.get(
+			`/search?query=${query}&page=${page}&size=${size}`
+		)
 		return convert(response.data) as api.SearchResults
 	} catch (e) {
 		if (e.response.status === 400) {

--- a/src/ui/assets/styles/components/_pagination.scss
+++ b/src/ui/assets/styles/components/_pagination.scss
@@ -1,0 +1,60 @@
+$module: 'pager';
+
+.#{$module} {
+  margin-top: em(5, 16);
+  margin-bottom: em(20, 16);
+
+  @include media(tablet) {
+    margin-top: em(5);
+    margin-bottom: em(20);
+  }
+
+  &__controls {
+
+    @include media(tablet) {
+      float: right;
+    }
+  }
+
+  &__list {
+    display: none;
+
+    @include media(tablet) {
+      display: inline;
+
+      li {
+        display: inline;
+        margin: 0 5px;
+
+        &:first-child {
+          margin-left: 0;
+        }
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+
+  &__next,
+  &__prev {
+    margin-right: 10px;
+
+    @include media(tablet) {
+      margin-right: 0;
+    }
+  }
+
+  &__next {
+    @include media(tablet) {
+      margin-left: 10px;
+    }
+  }
+
+  &__prev {
+    @include media(tablet) {
+      margin-right: 10px;
+    }
+  }
+}

--- a/src/ui/assets/styles/main.scss
+++ b/src/ui/assets/styles/main.scss
@@ -31,6 +31,7 @@
 @import 'components/home-tile';
 @import 'components/tables';
 @import 'components/accessible-auto-complete';
+@import 'components/pagination';
 
 .phase-banner {
 	@extend %site-width-container;

--- a/src/ui/controllers/search.ts
+++ b/src/ui/controllers/search.ts
@@ -4,19 +4,48 @@ import * as api from 'lib/service/catalog/api'
 import * as template from 'lib/ui/template'
 import * as striptags from 'striptags'
 
+function range(start: number, stop?: number, step?: number) {
+	const out = []
+	if (stop === undefined) {
+		stop = start
+		start = 0
+	}
+	if (step) {
+		while (stop > start) {
+			out.push(start)
+			start += step
+		}
+	} else {
+		while (stop > start) {
+			out.push(start)
+			start += 1
+		}
+	}
+	return out
+}
+
 export async function search(req: express.Request, res: express.Response) {
 	let query = ''
+	let page = 0
+	let size = 10
+
 	let searchResults: api.SearchResults = {
 		page: 0,
 		results: [],
-		size: 20,
+		size: 10,
 		totalResults: 0,
 	}
 	const start = new Date()
+	if (req.query.p){
+		page = req.query.p
+	}
+	if (req.query.p){
+		size = req.query.s
+	}
 	if (req.query.q) {
 		query = striptags(req.query.q)
-		searchResults = await catalog.search(query)
+		searchResults = await catalog.search(query, page, size)
 	}
 	const end: string = (((new Date() as any) - (start as any)) / 1000).toFixed(2)
-	res.send(template.render('search', req, res, {end, query, searchResults}))
+	res.send(template.render('search', req, res, {end, query, searchResults, range}))
 }

--- a/src/ui/controllers/search.ts
+++ b/src/ui/controllers/search.ts
@@ -39,7 +39,7 @@ export async function search(req: express.Request, res: express.Response) {
 	if (req.query.p){
 		page = req.query.p
 	}
-	if (req.query.p){
+	if (req.query.s){
 		size = req.query.s
 	}
 	if (req.query.q) {

--- a/src/ui/controllers/search.ts
+++ b/src/ui/controllers/search.ts
@@ -36,10 +36,10 @@ export async function search(req: express.Request, res: express.Response) {
 		totalResults: 0,
 	}
 	const start = new Date()
-	if (req.query.p){
+	if (req.query.p) {
 		page = req.query.p
 	}
-	if (req.query.s){
+	if (req.query.s) {
 		size = req.query.s
 	}
 	if (req.query.q) {
@@ -47,5 +47,7 @@ export async function search(req: express.Request, res: express.Response) {
 		searchResults = await catalog.search(query, page, size)
 	}
 	const end: string = (((new Date() as any) - (start as any)) / 1000).toFixed(2)
-	res.send(template.render('search', req, res, {end, query, searchResults, range}))
+	res.send(
+		template.render('search', req, res, {end, query, searchResults, range})
+	)
 }

--- a/src/ui/page/search/index.html
+++ b/src/ui/page/search/index.html
@@ -87,6 +87,4 @@
         </div>
         {{/if}}
     </div>
-    <script>
-    </script>
 </Page>

--- a/src/ui/page/search/index.html
+++ b/src/ui/page/search/index.html
@@ -58,5 +58,50 @@
                 </div>
             </div>
         </div>
+        <div class="pager">
+            <div class="pager__controls">
+                <a class="pager__prev" href="#">Prev</a>
+                <ul class="pager__list">
+                    <li>
+                        <a href="#">
+                            1
+                        </a>
+                    </li>
+                    <li>
+                        2
+                    </li>
+                    <li>
+                        <a href="#">
+                            3
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#">
+                            4
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#">
+                            5
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#">
+                            6
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#">
+                            7
+                        </a>
+                    </li>
+                </ul>
+                <a class="pager__next" href="#">Next</a>
+            </div>
+            <p>{{searchResults.size}}</p>
+            <p>{{(searchResults.page+1)}}</p>
+            <p>{{searchResults.totalResults}}</p>
+            <div class="pager__summary">Showing {{(searchResults.page+1)}} – 20 of {{searchResults.totalResults}} items</div>
+        </div>
     </div>
 </Page>

--- a/src/ui/page/search/index.html
+++ b/src/ui/page/search/index.html
@@ -64,17 +64,21 @@
                 {{#if searchResults.page > 0}}
                 <a class="pager__prev" href="/search?q={{query}}&s={{searchResults.size}}&p={{searchResults.page - 1}}">Prev</a>
                 {{/if}}
+
+                {{#if Math.ceil(searchResults.totalResults/searchResults.size) != 1}}
                 <ul class="pager__list">
                     {{#each range(Math.ceil(searchResults.totalResults/searchResults.size)) as x}}
                     <li>
                         {{#if x === searchResults.page}}
-                        {{x+1}}
+                        <span>{{x+1}}</span>
                         {{else}}
                         <a href="/search?q={{query}}&s={{searchResults.size}}&p={{x}}">{{x+1}}</a>
                         {{/if}}
                     </li>
                     {{/each}}
                 </ul>
+                {{/if}}
+
                 {{#if searchResults.page != (Math.ceil(searchResults.totalResults/searchResults.size)-1)}}
                 <a class="pager__next" href="/search?q={{query}}&s={{searchResults.size}}&p={{searchResults.page + 1}}">Next</a>
                 {{/if}}

--- a/src/ui/page/search/index.html
+++ b/src/ui/page/search/index.html
@@ -58,50 +58,31 @@
                 </div>
             </div>
         </div>
+        {{#if searchResults.totalResults !== 0}}
         <div class="pager">
             <div class="pager__controls">
-                <a class="pager__prev" href="#">Prev</a>
+                {{#if searchResults.page > 0}}
+                <a class="pager__prev" href="/search?q={{query}}&s={{searchResults.size}}&p={{searchResults.page - 1}}">Prev</a>
+                {{/if}}
                 <ul class="pager__list">
+                    {{#each range(Math.ceil(searchResults.totalResults/searchResults.size)) as x}}
                     <li>
-                        <a href="#">
-                            1
-                        </a>
+                        {{#if x === searchResults.page}}
+                        {{x+1}}
+                        {{else}}
+                        <a href="/search?q={{query}}&s={{searchResults.size}}&p={{x}}">{{x+1}}</a>
+                        {{/if}}
                     </li>
-                    <li>
-                        2
-                    </li>
-                    <li>
-                        <a href="#">
-                            3
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            4
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            5
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            6
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            7
-                        </a>
-                    </li>
+                    {{/each}}
                 </ul>
-                <a class="pager__next" href="#">Next</a>
+                {{#if searchResults.page != (Math.ceil(searchResults.totalResults/searchResults.size)-1)}}
+                <a class="pager__next" href="/search?q={{query}}&s={{searchResults.size}}&p={{searchResults.page + 1}}">Next</a>
+                {{/if}}
             </div>
-            <p>{{searchResults.size}}</p>
-            <p>{{(searchResults.page+1)}}</p>
-            <p>{{searchResults.totalResults}}</p>
-            <div class="pager__summary">Showing {{(searchResults.page+1)}} – 20 of {{searchResults.totalResults}} items</div>
+            <div class="pager__summary">Showing {{((searchResults.page*searchResults.size)+1)}} – {{((searchResults.page*searchResults.size)+searchResults.results.length)}} of {{searchResults.totalResults}} items</div>
         </div>
+        {{/if}}
     </div>
+    <script>
+    </script>
 </Page>


### PR DESCRIPTION
**Overview:**
- Adding pagination to search results screen
- The latest version of Learning catalogue (with pagination changes will be required to test)

**Changes:**
- Pages and respective links should be dynamically added based upon search query, page size and page number
- The next/prev links should be hidden at the start and end of the page set
- The current page should not have a link
- If there are no results from a query, no result/page information should be shown
- If there is only one page of results, pagination links should not appear
- Adding _each range logic_ in templates courtesy of @tav 

**Concerns:**
- Currently the user can manually set the url to be e.g. page=99999, effectively setting the returning results to be out of bounds. Need to determine correct behaviour.
- If the user sets the page size to be 1, and there >10 results shown, it will display a page link for each of these page. This would be a problem if there are hundreds of results returned. However as the current data size is relatively small, we shouldn't have any major problems.