### PR TITLE
bug/LPFG-190

### DIFF
--- a/src/management-ui/controllers/module/edit.ts
+++ b/src/management-ui/controllers/module/edit.ts
@@ -208,7 +208,8 @@ export async function setModule(ireq: express.Request, res: express.Response) {
 				res.sendStatus(500)
 				return
 			}
-			req.course.duration = duration
+			// req.course.duration = duration
+			data.duration = duration
 			data.title = data.title || info.title
 		}
 

--- a/src/ui/assets/styles/components/_discite.scss
+++ b/src/ui/assets/styles/components/_discite.scss
@@ -140,6 +140,10 @@ $module: 'discite';
 		}
 	}
 
+	@include e(counter) {
+		margin-bottom: 0;
+	}
+
 	@include e(action) {
 		//div.discite__action
 		@extend %disciteRowDiv;

--- a/src/ui/assets/styles/components/_discite.scss
+++ b/src/ui/assets/styles/components/_discite.scss
@@ -81,6 +81,8 @@ $module: 'discite';
 			//this should not be here, .badge is being imported too late in main.scss
 			@include m(discite) {
 				margin-bottom: 0;
+				position: absolute;
+				right: 0;
 			}
 		}
 

--- a/src/ui/component/DisciteCourse.html
+++ b/src/ui/component/DisciteCourse.html
@@ -24,6 +24,7 @@
             </li>
             <li class="discite__property-item">
                 <span class="visuallyhidden">Duration:</span> {{course.getDuration()}}
+
             </li>
             {{#if !course.isRequired(signedInUser)}}
             <li class="discite__property-item">
@@ -34,7 +35,7 @@
     </div>
     {{#if course.modules.length > 1 }}
         <div class="discite__area">
-            <p class="font-small">
+            <p class="font-small discite__counter">
                 This course comprises of {{course.modules.length}} modules
             </p>
         </div>


### PR DESCRIPTION
**PR includes**

* styling fix for DisciteCourse - progress badge was "pushing down" the other course info, so it would overflow if the course description was too short
* removed margin-bottom for the module counter thingy
* Fix for video times. duration was not being saved to module, so there would be either no time, or an old time
