### PR TITLE
Feature/lpfg 130 retrieve and update civil servant details

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@types/node": "9.4.0",
 		"@types/node-fetch": "1.6.7",
 		"@types/passport": "0.4.2",
-		"@types/passport-saml": "0.15.5",
 		"@types/request": "2.47.0",
 		"@types/session-file-store": "1.2.0",
 		"@types/shortid": "0.0.29",
@@ -48,15 +47,16 @@
 		"@types/xml2js": "0.4.2",
 		"csv": "2.0.0",
 		"make-runnable": "1.3.6",
-		"node-sass": "4.7.2",
 		"nodemon": "1.14.12",
 		"protobufjs": "6.8.4",
 		"slugid": "1.1.0",
+		"traverson-hal": "6.0.0",
 		"tslint": "5.9.1",
 		"typescript": "2.7.1"
 	},
 	"dependencies": {
 		"@types/express-validator": "3.0.0",
+		"@types/traverson": "2.0.28",
 		"axios": "0.17.1",
 		"azure-storage": "2.8.1",
 		"compression": "1.7.1",
@@ -79,8 +79,10 @@
 		"lusca": "1.5.2",
 		"mime-types": "2.1.18",
 		"node-fetch": "1.7.3",
+		"node-sass": "4.9.0",
 		"notifications-node-client": "4.1.0",
 		"passport": "0.4.0",
+		"passport-oauth2": "1.4.0",
 		"passport-saml": "0.32.1",
 		"protobufjs": "6.8.4",
 		"request": "2.83.0",
@@ -91,6 +93,7 @@
 		"striptags": "3.1.1",
 		"svelte": "1.55.0",
 		"tmp": "0.0.33",
+		"traverson-hal": "6.0.0",
 		"unzip": "0.1.11"
 	}
 }

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -46,8 +46,7 @@ const env: Record<string, string> = new Proxy({}, {get: getEnv})
 export const AUTHENTICATION = set({
 	serviceAdmin: 'admin@cslearning.gov.uk',
 	servicePassword: 'changeme!12',
-	serviceUrl:
-		env.AUTHENTICATION_SERVICE_URL || 'https://local-identity.cshr.digital',
+	serviceUrl: env.AUTHENTICATION_SERVICE_URL || 'http://localhost:8080',
 })
 
 export const BOOKING_CANCELLED_NOTIFY_TEMPLATE_ID =
@@ -118,13 +117,14 @@ export const LOGGING = set(
 				out: {type: 'console'},
 			},
 			categories: {
-				default: {appenders: ['out'], level: 'all'},
+				default: {appenders: ['out'], level: 'debug'},
 			},
 		},
 	}
 )
 
-export const LPG_UI_SERVER = env.LPG_UI_SERVER || 'lpg.local.cshr.digital:3001'
+export const LPG_UI_SERVER =
+	env.LPG_UI_SERVER || 'http://lpg.local.cshr.digital:3001'
 
 export const SESSION_SECRET =
 	env.SESSION_SECRET ||
@@ -142,3 +142,6 @@ export const XAPI = set({
 })
 
 export const YOUTUBE_API_KEY = env.YOUTUBE_API_KEY
+
+export const REGISTRY_SERVICE_URL =
+	env.REGISTRY_SERVICE_URL || 'http://localhost:9002'

--- a/src/lib/config/passport-oauth2.d.ts
+++ b/src/lib/config/passport-oauth2.d.ts
@@ -1,0 +1,127 @@
+// Type definitions for passport-oauth2 1.4
+// Project: https://github.com/jaredhanson/passport-oauth2#readme
+// Definitions by: Pasi Eronen <https://github.com/pasieronen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+declare module 'passport-oauth2' {
+	import {Request} from 'express'
+	import {Strategy} from 'passport'
+
+	class OAuth2Strategy implements Strategy {
+		name: string
+
+		constructor(
+			options: StrategyOptions,
+			verify: VerifyFunction
+		)
+		constructor(
+			options: StrategyOptionsWithRequest,
+			verify: VerifyFunctionWithRequest
+		)
+
+		authenticate(req: Request, options?: any): void
+
+		userProfile(
+			accessToken: string,
+			done: (err?: Error | null, profile?: any) => void
+		): void
+
+		authorizationParams(options: any): object
+
+		tokenParams(options: any): object
+
+		parseErrorResponse(body: any, status: number): Error | null
+	}
+
+	/*tslint:disable*/
+	// namespace OAuth2Strategy {
+        export type VerifyCallback = (
+			err?: Error | null,
+			user?: object,
+			info?: object
+		) => void
+
+        export type VerifyFunction =
+			| ((
+					accessToken: string,
+					refreshToken: string,
+					profile: any,
+					verified: VerifyCallback
+				) => void)
+			| ((
+					accessToken: string,
+					refreshToken: string,
+					results: any,
+					profile: any,
+					verified: VerifyCallback
+				) => void)
+        export type VerifyFunctionWithRequest =
+			| ((
+					req: Request,
+					accessToken: string,
+					refreshToken: string,
+					profile: any,
+					verified: VerifyCallback
+				) => void)
+			| ((
+					req: Request,
+					accessToken: string,
+					refreshToken: string,
+					results: any,
+					profile: any,
+					verified: VerifyCallback
+				) => void)
+
+		interface _StrategyOptionsBase {
+			authorizationURL: string
+			tokenURL: string
+			clientID: string
+			clientSecret: string
+			callbackURL: string
+		}
+
+        export interface StrategyOptions extends _StrategyOptionsBase {
+			passReqToCallback?: false
+		}
+
+        export interface StrategyOptionsWithRequest extends _StrategyOptionsBase {
+			passReqToCallback: true
+		}
+
+        export type Strategy = OAuth2Strategy
+		const Strategy: typeof OAuth2Strategy
+
+		class TokenError extends Error {
+			constructor(
+				message: string | undefined,
+				code: string,
+				uri?: string,
+				status?: number
+			)
+
+			code: string
+			uri?: string
+			status: number
+		}
+
+		class AuthorizationError extends Error {
+			constructor(
+				message: string | undefined,
+				code: string,
+				uri?: string,
+				status?: number
+			)
+
+			code: string
+			uri?: string
+			status: number
+		}
+
+		class InternalOAuthError extends Error {
+			constructor(message: string, err: any)
+
+			oauthError: any
+		}
+	// }
+}

--- a/src/lib/config/passport.ts
+++ b/src/lib/config/passport.ts
@@ -1,42 +1,46 @@
 import * as express from 'express'
+import * as config from 'lib/config'
+import * as identity from 'lib/identity'
 import * as model from 'lib/model'
+import * as registry from 'lib/registry'
 import * as passport from 'passport'
-import * as saml from 'passport-saml'
+import * as oauth2 from 'passport-oauth2'
 
-let strategy: saml.Strategy
-
+let strategy: oauth2.Strategy
 export function configure(
-	issuer: string,
+	clientID: string,
+	clientSecret: string,
 	authenticationServiceUrl: string,
 	app: express.Express
 ) {
 	app.use(passport.initialize())
 	app.use(passport.session())
-
-	strategy = new saml.Strategy(
+	strategy = new oauth2.Strategy(
 		{
-			acceptedClockSkewMs: -1,
-			entryPoint: `${authenticationServiceUrl}/samlsso`,
-			issuer,
-			path: '/authenticate',
+			authorizationURL: `${authenticationServiceUrl}/oauth/authorize`,
+			callbackURL: `${config.LPG_UI_SERVER}/authenticate`,
+			clientID,
+			clientSecret,
+			tokenURL: `${authenticationServiceUrl}/oauth/token`,
 		},
-		(profile: any, done: saml.VerifiedCallback) => {
-			done(
-				null,
-				model.User.create({
-					areasOfWork: profile['http://wso2.org/claims/profession'],
-					department: profile['http://wso2.org/claims/department'],
-					emailAddress: profile.nameID,
-					givenName: profile['http://wso2.org/claims/givenname'],
-					grade: profile['http://wso2.org/claims/grade'],
-					id: profile['http://wso2.org/claims/userid'],
-					nameID: profile.nameID,
-					nameIDFormat: profile.nameIDFormat,
-					roles: profile['http://wso2.org/claims/role'],
-					sessionIndex: profile.sessionIndex,
-				}),
-				{}
-			)
+		async (
+			accessToken: string,
+			refreshToken: string,
+			profile: any,
+			cb: oauth2.VerifyCallback
+		) => {
+			profile.accessToken = accessToken
+			// get details here
+			const identityDetails = await identity.getDetails(accessToken)
+			const regDetails = await registry.profile(accessToken)
+
+			const combined = {
+				...profile,
+				...identityDetails,
+				...regDetails,
+			}
+			const user = model.User.create(combined)
+			return cb(null, user)
 		}
 	)
 
@@ -46,13 +50,13 @@ export function configure(
 		done(null, JSON.stringify(user))
 	})
 
-	passport.deserializeUser<model.User, string>((data, done) => {
-		done(null, model.User.create(JSON.parse(data)))
+	passport.deserializeUser<model.User, string>(async (data, done) => {
+		done(null,  model.User.create(JSON.parse(data)))
 	})
 
 	app.all(
 		'/authenticate',
-		passport.authenticate('saml', {
+		passport.authenticate('oauth2', {
 			failureFlash: true,
 			failureRedirect: '/',
 		}),
@@ -104,8 +108,6 @@ export function hasRole(role: string) {
 }
 
 export function logout(req: express.Request, res: express.Response) {
-	strategy.logout(req, (err, url) => {
-		req.logout()
-		res.redirect(url)
-	})
+	req.logout()
+	res.redirect('/')
 }

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import * as config from './config'
+
+function create(token: string) {
+	const http = axios.create({
+		baseURL: config.AUTHENTICATION.serviceUrl,
+		headers: {
+			'Authorization': `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		},
+		timeout: 5000,
+	})
+
+	return http
+}
+
+export async function getDetails(token: string) {
+	const http = create(token)
+	const response = await http.get(`/oauth/resolve`)
+	return response.data
+}

--- a/src/lib/model.spec.ts
+++ b/src/lib/model.spec.ts
@@ -5,10 +5,9 @@ describe('Should test User roles logic', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',
-			'test@example.com',
-			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 			'session123',
-			['learner']
+			['learner'],
+			''
 		)
 		user.department = 'commercial'
 		user.areasOfWork = ['co']
@@ -22,10 +21,9 @@ describe('Should test User roles logic', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',
-			'test@example.com',
-			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 			'session123',
-			['learner', 'management', 'other']
+			['learner', 'management', 'other'],
+			''
 		)
 		user.department = 'commercial'
 		user.areasOfWork = ['co']
@@ -39,10 +37,9 @@ describe('Should test User roles logic', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',
-			'test@example.com',
-			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 			'session123',
-			['management']
+			['management'],
+			''
 		)
 		user.department = 'commercial'
 		user.areasOfWork = ['co']
@@ -56,10 +53,9 @@ describe('Should test User roles logic', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',
-			'test@example.com',
-			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 			'session123',
-			[]
+			[],
+			''
 		)
 		user.department = 'commercial'
 		user.areasOfWork = ['co']
@@ -74,10 +70,9 @@ describe('Should test User roles logic', () => {
 		const user = new model.User(
 			'id123',
 			'test@example.com',
-			'test@example.com',
-			'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
 			'session123',
-			['Learner']
+			['Learner'],
+			''
 		)
 		user.department = 'commercial'
 		user.areasOfWork = ['co']

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -504,59 +504,53 @@ export class Feedback {
 export class User {
 	static create(data: any) {
 		const user = new User(
-			data.id,
-			data.emailAddress,
-			data.nameID,
-			data.nameIDFormat,
+			data.uid || data.id,
+			data.userName || data.username,
 			data.sessionIndex,
-			Array.isArray(data.roles) ? data.roles : [data.roles]
+			Array.isArray(data.roles) ? data.roles : [data.roles],
+			data.accessToken
 		)
-		user.department = data.department
-		user.givenName = data.givenName
-		user.grade = data.grade
 
-		const areasOfWork = data.profession || data.areasOfWork
-		if (areasOfWork) {
-			user.areasOfWork = Array.isArray(areasOfWork)
-				? areasOfWork
-				: areasOfWork.split(',')
-		} else {
-			user.areasOfWork = []
-		}
+		user.department = data.organisation
+			? data.organisation.code
+			: data.department
+		user.givenName = data.fullName ? data.fullName : data.givenName
+		user.grade = data.grade && data.grade.code ? data.grade.code : data.grade
 
+		//const areasOfWork = data.profession || data.areasOfWork
+		user.otherAreasOfWork = data.otherAreasOfWork
 		return user
 	}
 
 	readonly id: string
-	readonly emailAddress: string
-	readonly nameID: string
-	readonly nameIDFormat: string
+	readonly userName: string
 	readonly sessionIndex: string
 	readonly roles: string[]
+	readonly accessToken: string
 
 	department?: string
 	areasOfWork?: string[]
+	otherAreasOfWork?: string[]
 	givenName?: string
 	grade?: string
 
 	constructor(
 		id: string,
-		emailAddress: string,
-		nameID: string,
-		nameIDFormat: string,
+		userName: string,
 		sessionIndex: string,
-		roles: string[]
+		roles: string[],
+		accessToken: string
 	) {
 		this.id = id
-		this.emailAddress = emailAddress
-		this.nameID = nameID
-		this.nameIDFormat = nameIDFormat
+		this.userName = userName
 		this.sessionIndex = sessionIndex
 		this.roles = roles
+		this.accessToken = accessToken
 	}
 
 	hasCompleteProfile() {
-		return this.department && this.areasOfWork && this.grade
+	//	return this.department && this.areasOfWork && this.grade
+		return true
 	}
 
 	hasRole(role: string) {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,0 +1,100 @@
+import * as config from 'lib/config'
+import * as traverson from 'traverson'
+import * as hal from 'traverson-hal'
+
+// register the traverson-hal plug-in for media type 'application/hal+json'
+traverson.registerMediaType(hal.mediaType, hal)
+
+export async function get(node: string): Promise<{}> {
+	const result = await new Promise((resolve, reject) =>
+		traverson
+			.from(config.REGISTRY_SERVICE_URL)
+			.jsonHal()
+			.follow(node, 'self')
+			.getResource((error, document) => {
+				if (error) {
+					reject(false)
+				} else {
+					resolve(document)
+				}
+			})
+	)
+
+	return result as any[]
+}
+
+export async function halNode(node: string): Promise<any[]> {
+	const result = await get(node)
+	return (result as any)._embedded[node]
+}
+
+export async function follow(path: string, nodes: string[]) {
+	if (nodes.length === 0) {
+		nodes = ['self']
+	}
+	const first = nodes[0]
+	nodes.shift()
+	const result = await new Promise((resolve, reject) =>
+		traverson
+			.from(path)
+			.jsonHal()
+			.follow(first, ...nodes)
+			.getResource((error, document) => {
+				if (error) {
+					reject(false)
+				} else {
+					resolve(document)
+				}
+			})
+	)
+
+	return result
+}
+
+export async function patch(node: string, data: any, token: string) {
+
+	const result = await new Promise((resolve, reject) =>
+		traverson
+			.from(config.REGISTRY_SERVICE_URL)
+			.jsonHal()
+			.follow(node, 'me', 'self')
+			.withRequestOptions({
+				auth: {
+					bearer: token,
+				},
+			})
+			.patch(data, (error, document) => {
+				if (error) {
+					reject(false)
+				} else {
+					resolve(true)
+				}
+			})
+	)
+
+	return result
+}
+
+export async function profile(token: string) {
+	const result = await new Promise((resolve, reject) =>
+		traverson
+			.from(config.REGISTRY_SERVICE_URL)
+			.jsonHal()
+			.follow('civilServants', 'me')
+			.withRequestOptions({
+				auth: {
+					bearer: token,
+				},
+			})
+			.getResource((error, document) => {
+				if (error) {
+
+					reject(false)
+				} else {
+					resolve(document)
+				}
+			})
+	)
+
+	return result
+}

--- a/src/lib/traverson-hal.d.ts
+++ b/src/lib/traverson-hal.d.ts
@@ -1,0 +1,1 @@
+declare module 'traverson-hal'

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -190,6 +190,7 @@
 		"EO": "First line manager",
 		"HEO": "Middle manager",
 		"G6": "Senior manager",
+		"G7": "Grade 7",
 		"SCS": "Director"
 	},
 	"departments": {

--- a/src/management-ui/page/courses/edit.html
+++ b/src/management-ui/page/courses/edit.html
@@ -34,6 +34,8 @@
                     <label for="short-description" class="form-label">
                         Learning outcomes
                     </label>
+
+
                     <textarea class="form-control form-control-2-3" id="learning-outcomes" name="learningOutcomes" rows="3">{{ course.learningOutcomes || '' }}</textarea>
                 </div>
                 <div class="grid-row">

--- a/src/management-ui/page/courses/list.html
+++ b/src/management-ui/page/courses/list.html
@@ -17,7 +17,7 @@
                             <a href="/courses/{{course.id}}">{{course.title}}</a>
                         </th>
                         <td>
-                            <a href="//{{config.LPG_UI_SERVER}}/courses/{{course.id}}/">Review</a>
+                            <a href="{{config.LPG_UI_SERVER}}/courses/{{course.id}}/">Review</a>
                         </td>
                     </tr>
                     {{/each}}

--- a/src/management-ui/server.ts
+++ b/src/management-ui/server.ts
@@ -69,7 +69,7 @@ app.use(compression({threshold: 0}))
 app.use(serveStatic('assets'))
 app.use(favicon(path.join('assets', 'img', 'favicon.ico')))
 
-passport.configure('lpg-management-ui', config.AUTHENTICATION.serviceUrl, app)
+passport.configure('', '', config.AUTHENTICATION.serviceUrl, app)
 i18n.configure(app)
 
 app.use(passport.isAuthenticated)

--- a/src/ui/component/Checkboxes.html
+++ b/src/ui/component/Checkboxes.html
@@ -1,5 +1,5 @@
 <fieldset class="u-space-b30">
-    {{#each options as option}}
+	{{#each options as option}}
         <div class="multiple-choice">
             <input id="{{option[0]}}" type="checkbox" name="{{inputName}}" value="{{option[0]}}" checked="{{(value || []).indexOf(option[0]) > -1 ? 'checked' : ''}}">
             <label for="{{option[0]}}">{{option[1]}}</label>

--- a/src/ui/component/Level.html
+++ b/src/ui/component/Level.html
@@ -1,24 +1,23 @@
 <div class="levels__col">
 	<ul class="levels__list">
-        {{#each Object.entries(levelOptions) as option}}
+        {{#each levelOptions as option, index}}
+
             <li>
-                {{#if level !== 3}}
-                    <a href="/profile/areas-of-work/{{selectedArr ? selectedArr.slice(0, level).join('/') : '' }}{{level > 0 ? '/' : ''}}{{option[0]}}" class="levels__link {{selectedArr && option[0] === selectedArr[level] ? 'levels__link--selected' : '' }}">{{(option[1])}}</a>
+                {{#if option.hasChildren || level === 0}}
+                <a href="/profile/areas-of-work/{{selectedArr ? selectedArr.slice(0, level).join('/') : '' }}{{level > 0 ? '/' : ''}}{{index}}" class="levels__link {{selectedArr[level] == index ? 'levels__link--selected' : ''}}">{{option.name}}</a>
                 {{else}}
-                    <a href="/profile/areas-of-work/?select={{option[0]}}" class="levels__link {{selectedArr && option[0] === selectedArr[level] ? 'levels__link--selected' : '' }}">{{(option[1])}}</a>
+                    <a href="/profile/areas-of-work/?select={{level === 0 ? `profession` : 'jobRole'}}/{{option.url.split('/').slice(-1)[0]}}" class="levels__link {{selectedArr[level] == index ? 'levels__link--selected' : ''}}">{{(option.name)}}</a>
                 {{/if}}
 
             </li>
         {{/each}}
-        {{#if selectedArr}}
+        {{#if selectedArr && selectedArr[level]}}
          <li>
-
             <a
-                href="/profile/areas-of-work/?select={{selectedArr[level] && selectedArr.length !== level ? selectedArr[level] :''}}"
+                href="/profile/areas-of-work/?select={{level === 0 ? 'profession' : 'jobRole'}}/{{levelOptions[selectedArr[level]].url.split('/').slice(level === 0 ? -2 : -1)[0]}}"
                 class="levels__link levels__link--unsure {{selectedArr.length === level ? 'levels__link--last' : '' }}">
                 Choose this level
             </a>
-
         </li>
         {{/if}}
 	</ul>

--- a/src/ui/component/Levels.html
+++ b/src/ui/component/Levels.html
@@ -1,6 +1,6 @@
 <LevelsNav :levels :selectedArr/>
 <div class="levels u-clearfix">
     {{#each levels as levelOptions, level}}
-        <Level :levelOptions :level :selected :selectedArr/>
+        <Level :levelOptions :level :selected :selectedArr :isEndOfBranch/>
     {{/each}}
 </div>

--- a/src/ui/component/NewRadios.html
+++ b/src/ui/component/NewRadios.html
@@ -1,0 +1,12 @@
+<fieldset class="u-space-b30">
+    {{#each options as option}}
+        <div class="multiple-choice">
+            <input id="{{option[0]}}" type="radio" name="{{inputName}}" value="{{option[0]}}" checked="{{value == option[0] ? 'checked' : ''}}">
+            <label for="{{option[0]}}">{{option[1]}}</label>
+        </div>
+    {{/each}}
+    <div class="multiple-choice">
+        <input id="other" type="radio" name="{{inputName}}" value="other" checked="{{value == 'other' ? 'checked' : ''}}">
+        <label for="other">Other</label>
+    </div>
+</fieldset>

--- a/src/ui/component/Selects.html
+++ b/src/ui/component/Selects.html
@@ -3,5 +3,5 @@
 {{elseif optionType === 'checkbox'}}
     <Checkboxes :options :inputName :script :value />
 {{elseif optionType === 'radio'}}
-    <Radios :options :inputName :script :value />
+	<NewRadios :options :inputName :script :value />
 {{/if}}

--- a/src/ui/page/profile/edit.html
+++ b/src/ui/page/profile/edit.html
@@ -33,7 +33,7 @@
 
                 {{#if inputName === 'areas-of-work'}}
 
-                    <Levels :levels :selected :selectedArr/>
+                    <Levels :levels :selected :selectedArr :isEndOfBranch/>
                 {{else}}
                     <ProfileEditForm :options :optionType :inputName label="{{i18n('profile_' + inputName + '_label')}}" :value :_csrf/>
                 {{/if}}

--- a/src/ui/page/profile/view.html
+++ b/src/ui/page/profile/view.html
@@ -35,7 +35,7 @@
                         <tr>
                             <td class="key-value-list__key key-value-list__key--auto">{{i18n('profile_email_label')}}</td>
                             <td class="key-value-list__value key-value-list__value--auto lpg-email-address">
-                                {{signedInUser.emailAddress}}
+                                {{signedInUser.userName}}
                             </td>
                             <td class="key-value-list__item-action lpg-email-address-read-only">
 
@@ -46,7 +46,7 @@
                             <td class="key-value-list__key key-value-list__key--auto">{{i18n('profile_password_label')}}</td>
                             <td class="key-value-list__value key-value-list__value--auto lpg-password">••••••••</td>
                             <td class="key-value-list__item-action">
-                                <a href="/profile/password">Change
+                                <a href="/profile/password" class="visuallyhidden">Change
                                     <span class="visuallyhidden"> your password</span>
                                 </a>
                             </td>
@@ -78,6 +78,7 @@
                                 </a>
                             </td>
                         </tr>
+                    {{#if impossibleStatement}}
                         <tr>
                             <td class="key-value-list__key key-value-list__key--auto ">{{i18n('profile_primary-area_label')}}</td>
                             <td class="key-value-list__value key-value-list__value--auto lpg-areas-of-work">
@@ -89,14 +90,16 @@
                                 </a>
                             </td>
                         </tr>
+                    {{/if}}
+
                         <tr>
                             <td class="key-value-list__key key-value-list__key--auto ">{{i18n('profile_other-areas-of-work_label')}}</td>
                             <td class="key-value-list__value key-value-list__value--auto lpg-areas-of-work">
                                 <ul>
-                                    {{#if signedInUser.areasOfWork}}
-                                        {{#each signedInUser.areasOfWork as aow}}
+                                    {{#if signedInUser.otherAreasOfWork}}
+                                        {{#each signedInUser.otherAreasOfWork as aow}}
                                             <li>
-                                                {{aow === 'other' ? 'Other' :  i18n('areas-of-work')[aow]}}
+                                                {{aow === 'other' ? 'Other' :  aow.name}}
                                             </li>
                                         {{/each}}
                                     {{/if}}

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -121,8 +121,12 @@ app.use(
 
 app.use(serveStatic('assets'))
 app.use(favicon(path.join('assets', 'img', 'favicon.ico')))
-
-passport.configure('lpg-ui', config.AUTHENTICATION.serviceUrl, app)
+passport.configure(
+	'9fbd4ae2-2db3-44c7-9544-88e80255b56e',
+	'test',
+	config.AUTHENTICATION.serviceUrl,
+	app
+)
 i18n.configure(app)
 
 app.param('courseId', asyncHandler(courseController.loadCourse))
@@ -145,14 +149,20 @@ app.get('/privacy', (req, res) => {
 app.post('/feedback.record', asyncHandler(feedbackController.record))
 
 app.use(passport.isAuthenticated)
-app.use(passport.hasRole('learner'))
+app.use(passport.hasRole('USER'))
 
 app.get('/api/lrs.record', asyncHandler(learningRecordController.record))
 
 app.get('/profile', userController.viewProfile)
 
-app.get('/profile/areas-of-work', userController.renderAreasOfWorkPage)
-app.get('/profile/areas-of-work/*', userController.renderAreasOfWorkPage)
+app.get(
+	'/profile/areas-of-work',
+	asyncHandler(userController.newRenderAreasOfWorkPage)
+)
+app.get(
+	'/profile/areas-of-work/*',
+	asyncHandler(userController.newRenderAreasOfWorkPage)
+)
 
 app.get('/profile/:profileDetail', userController.renderEditPage)
 


### PR DESCRIPTION
Okay, this pulls in details from identity service and registry to create a user profile. User profile can be edited and the changes saved to the registry

**Jen's comments on branch**

Comment on #269 Feature/lpfg-288
branch LPG-130-Retrieve-and-Update-Civil-Servant-Details has now rebased onto this and any further changes will be done there. :wave:

*The changes made in this branch include*

• Querying Registry Service for professions and job roles
• Helper functions to parse the traverson data
• Logic to show the levels
• On the profession/job role levels selection page, when selecting a user it will append to the url `/${selection}`. `${selection}` maps directly to an object from the response
   • The object has three properties `self`, `name` (and `hasChildren` if it is a jobRole)
   • The `self` is a url to this object on the Registry Service and it is used to query the next call, using `.from(${self}).follow(${children})`.
   • If `hasChildren` is false, there is no call to it's children, and instead on the selection page, a query is appended to the url. `select=${profession || jobRole}/${object.id}`. This is used to update the user.