### PR TITLE
fix/fixing out of bounds issue

### DIFF
--- a/src/management-ui/component/Checkboxes.html
+++ b/src/management-ui/component/Checkboxes.html
@@ -1,8 +1,7 @@
 <fieldset class="u-space-b30">
     {#each options as option}
     <div class="multiple-choice">
-
-        <input id="{option[0]}" type="checkbox" name="{node}" value="{option[0]}" checked="{ value.indexOf(option[1]) >=0 ? 'checked' : '' }">
+        <input id="{option[0]}" type="checkbox" name="{node}" value="{option[0]}" checked="{ values.indexOf(option[0]) >=0 ? 'checked' : '' }">
         <label for="{option[0]}">{option[1]}</label>
     </div>
     {/each}


### PR DESCRIPTION
There exists a bug on latest master where the checkbox selectors on lpg-management are throwing null pointers.

Reverting changes made a few weeks ago.

Have tested locally with Will.

_Note: there appears to be a difference in logic in how management and ui handle checkboxes. Will make more consistent at a later time._