### PR TITLE
LPFG-780: Links and Videos now open overview page first

### DIFF
--- a/src/ui/component/Layout.html
+++ b/src/ui/component/Layout.html
@@ -22,7 +22,6 @@
 		components: {
 			Footer,
 			Feedback,
-
 		}
 	};
 </script>

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -154,7 +154,7 @@ export async function display(ireq: express.Request, res: express.Response) {
 			}
 		case 'file':
 		case 'link':
-	        case 'video':
+		case 'video':
 		case 'blended':
 			const record = await learnerRecord.getRecord(req.user, course)
 			const modules = course.modules.map(cm => {

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -112,7 +112,7 @@ export async function displayModule(
 			)
 
 			res.send(
-				template.render(`course/video`, req, res, {
+				template.render(`course/display-video`, req, res, {
 					course,
 					courseDetails: getCourseDetails(req, course, module),
 					module,
@@ -153,6 +153,8 @@ export async function display(ireq: express.Request, res: express.Response) {
 					organisation.department.paymentMethods.indexOf('PURCHASE_ORDER') > -1
 			}
 		case 'file':
+        case 'link':
+        case 'video':
 		case 'blended':
 			const record = await learnerRecord.getRecord(req.user, course)
 			const modules = course.modules.map(cm => {
@@ -176,10 +178,6 @@ export async function display(ireq: express.Request, res: express.Response) {
 					modules,
 				})
 			)
-			break
-		case 'link':
-		case 'video':
-			res.redirect(`/courses/${course.id}/${module!.id}`)
 			break
 		default:
 			logger.debug(`Unknown course type: ${type}`)

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -91,7 +91,8 @@ export async function displayModule(
 	switch (module.type) {
 		case 'elearning':
 		res.redirect(
-			`${module.url}/${module.startPage}?title=${module.title || course.title}&module=${module.id}&endpoint=${config.LPG_UI_SERVER}/courses/${course.id}/${module.id}/xapi/&actor={"name":"Noop"}`
+			`${module.url}/${module.startPage}?title=${module.title || course.title}
+			&module=${module.id}&endpoint=${config.LPG_UI_SERVER}/courses/${course.id}/${module.id}/xapi/&actor={"name":"Noop"}`
 		)
 		break
 		case 'face-to-face':

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -153,8 +153,8 @@ export async function display(ireq: express.Request, res: express.Response) {
 					organisation.department.paymentMethods.indexOf('PURCHASE_ORDER') > -1
 			}
 		case 'file':
-        case 'link':
-        case 'video':
+		case 'link':
+	        case 'video':
 		case 'blended':
 			const record = await learnerRecord.getRecord(req.user, course)
 			const modules = course.modules.map(cm => {

--- a/src/ui/page/course/display-video.html
+++ b/src/ui/page/course/display-video.html
@@ -7,7 +7,7 @@
             <div class="column-two-thirds">
                 <div class="aspect__container">
                     <div class="video aspect__content">
-						{#if video != null}
+						{#if !module.url.endsWith('.mp4') }
                        		<div id="video-player"></div>
                         	<noscript>
                             	<iframe title="{module.title || course.title}" src="https://www.youtube.com/embed/{video.id}" frameborder="0" scrolling="no"></iframe>
@@ -15,43 +15,40 @@
 							<input type="hidden" id="video-id" value="{video.id}">
 						{:else}
 						<video id="videojs-player" class="video-js" controls preload="auto" width="640" height="400" data-setup="">
-						  <source src="{ module.url }" type='video/mp4'>
+						  <source src="{ module.location }" type='video/mp4'>
 						  <p class="vjs-no-js">
 							To view this video please enable JavaScript, and consider upgrading to a web browser that
-							<a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
+							<a href="http://videojs.com/html5-video-support/display-video.html" target="_blank">supports HTML5 video</a>
 						  </p>
 						</video>
-                <div>{@html $toHtml(course.description)}</div>
-                {#if course.learningOutcomes}
-                <h2 class="heading-medium">Learning outcomes</h2>
-                <div>{@html $toHtml(course.learningOutcomes)}</div>
-                {/if}
-                <DisciteModule {course} {module}/>
+
+						<script src="js/video.min.js"></script>
+						{/if}
+						<script src="js/video.js"></script>
+
+                        <input type="hidden" id="course-id" value="{course.id}">
+                        <input type="hidden" id="module-id" value="{module.id}">
+						<input type="hidden" id="session-id" value="{sessionId}">
+                    </div>
+                </div>
             </div>
             <div class="column-one-third">
-                {#if courseDetails.length} {#each courseDetails as dataRows}
-                <RightBox {dataRows}/>
-                {/each} {/if}
             </div>
         </div>
     </div>
 </Page>
 
 <script>
-    import Page from '../../component/Page.html'
-    import DisciteModule from '../../component/DisciteModule.html'
-    import RightBox from '../../component/Rightbox.html'
+	import Page from '../../component/Page.html'
 
-    export default {
-        data() {
-            return {
-            }
-        },
+	export default {
+		data() {
+			return {
+			}
+		},
 
-        components: {
-            Page,
-            DisciteModule,
-            RightBox
-        }
-    }
+		components: {
+			Page,
+		}
+	}
 </script>

--- a/src/ui/page/course/link.html
+++ b/src/ui/page/course/link.html
@@ -5,23 +5,8 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
-                <div class="aspect__container">
-                    <div class="video aspect__content">
-						{#if video != null}
-                       		<div id="video-player"></div>
-                        	<noscript>
-                            	<iframe title="{module.title || course.title}" src="https://www.youtube.com/embed/{video.id}" frameborder="0" scrolling="no"></iframe>
-							</noscript>
-							<input type="hidden" id="video-id" value="{video.id}">
-						{:else}
-						<video id="videojs-player" class="video-js" controls preload="auto" width="640" height="400" data-setup="">
-						  <source src="{ module.url }" type='video/mp4'>
-						  <p class="vjs-no-js">
-							To view this video please enable JavaScript, and consider upgrading to a web browser that
-							<a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
-						  </p>
-						</video>
                 <div>{@html $toHtml(course.description)}</div>
+
                 {#if course.learningOutcomes}
                 <h2 class="heading-medium">Learning outcomes</h2>
                 <div>{@html $toHtml(course.learningOutcomes)}</div>

--- a/src/ui/page/course/video.html
+++ b/src/ui/page/course/video.html
@@ -8,33 +8,39 @@
                 <div class="aspect__container">
                     <div class="video aspect__content">
 						{#if video != null}
-                       		<div id="video-player"></div>
+                       		<div id="video-player">
+                            </div>
                         	<noscript>
                             	<iframe title="{module.title || course.title}" src="https://www.youtube.com/embed/{video.id}" frameborder="0" scrolling="no"></iframe>
 							</noscript>
 							<input type="hidden" id="video-id" value="{video.id}">
 						{:else}
 						<video id="videojs-player" class="video-js" controls preload="auto" width="640" height="400" data-setup="">
-						  <source src="{ module.url }" type='video/mp4'>
+						  <source src="{ module.url }" type='video/mp4' />
 						  <p class="vjs-no-js">
 							To view this video please enable JavaScript, and consider upgrading to a web browser that
 							<a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
 						  </p>
 						</video>
-                <div>{@html $toHtml(course.description)}</div>
+                        {/if}
+                    </div> <!-- video aspect content end -->
+                    {@html $toHtml(course.description)}
+                </div>
                 {#if course.learningOutcomes}
                 <h2 class="heading-medium">Learning outcomes</h2>
-                <div>{@html $toHtml(course.learningOutcomes)}</div>
+                <div>
+                    {@html $toHtml(course.learningOutcomes)}
+                </div>
                 {/if}
                 <DisciteModule {course} {module}/>
-            </div>
+            </div> <!-- column 2 thirds end -->
             <div class="column-one-third">
                 {#if courseDetails.length} {#each courseDetails as dataRows}
                 <RightBox {dataRows}/>
                 {/each} {/if}
-            </div>
-        </div>
-    </div>
+            </div><!-- one third end -->
+        </div> <!--grid row end-->
+    </div><!-- end container -->
 </Page>
 
 <script>


### PR DESCRIPTION
This bug fix addresses courses with single link or video modules opening directly to the module instead of the course overview page.

Renamed video.html to display-video.html
Created video.html - now an overview page for a single video
Created link.html
Changed course/index.html such that video and link now have the same behaviour as blended and file
