### PR TITLE
LPFG-688: updating protobuf version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"passport": "0.4.0",
 		"passport-oauth2": "1.4.0",
 		"passport-saml": "0.32.1",
-		"protobufjs": "6.8.4",
+		"protobufjs": "6.8.6",
 		"request": "2.83.0",
 		"request-promise": "4.2.2",
 		"serve-favicon": "2.4.5",


### PR DESCRIPTION
Updating protobuf version as recommended by GH

![image](https://user-images.githubusercontent.com/11790473/46662713-157f0d80-cbb4-11e8-801a-d5e55a259378.png)

The `@types/` package is unaffected.