### PR TITLE
LPFG-963 Remove blog from search filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .env
 .idea
+.vscode
 .sessions
 dist/
 node_modules/

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -304,7 +304,6 @@
 		"assistant": "An assistant will accompany me"
 	},
 	"courseTypes": {
-		"blog": "Blog",
 		"face-to-face": "Face to face",
 		"link": "Link",
 		"elearning": "Online",


### PR DESCRIPTION
- removed 'Blog' entry from en.json. Since there are no blog course types, this only affects the search filter option.