### PR TITLE
LPFG-997: Set mandatory base on audience department and type

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -32,10 +32,10 @@ export class Course {
 			}
 			course.audience = matchedAudience
 
-			if (course.audience != null) {
-				course.audience!.mandatory = false
-				course.audience.departments.forEach((a) => {
-					if (a === user.department && course.audience!.type === Audience.Type.REQUIRED_LEARNING) {
+			if (course.audience) {
+				course.audience.mandatory = false
+				course.audience.departments.forEach(a => {
+					if (a === user.department && course.audience!.type === 'REQUIRED_LEARNING') {
 						course.audience!.mandatory = true
 					}
 				})
@@ -347,7 +347,7 @@ export class Audience {
 		audience.interests = data.interests || []
 		audience.mandatory = data.mandatory === undefined ? true : data.mandatory
 		audience.frequency = data.frequency
-		audience.type = data.type
+		audience.type = data.type ? data.type.toString() : null
 		if (data.requiredBy) {
 			audience.requiredBy = new Date(data.requiredBy)
 		}
@@ -361,7 +361,7 @@ export class Audience {
 	mandatory = false
 	requiredBy?: Date | null
 	frequency?: string
-	type: Audience.Type
+	type: string
 
 	get optional() {
 		return !this.mandatory
@@ -432,15 +432,6 @@ export class Audience {
 		const lastDate = Frequency.decrement(this.frequency, nextDate)
 		return [lastDate, nextDate]
 	}
-}
-
-export namespace Audience {
-	export enum Type {
-                OPEN,
-                CLOSED_COURSE,
-                PRIVATE_COURSE,
-                REQUIRED_LEARNING,
-        }
 }
 
 export class Frequency {

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -32,14 +32,14 @@ export class Course {
 			}
 			course.audience = matchedAudience
 
-            if(course.audience != null) {
-                course.audience!.mandatory = false
-                course.audience.departments.forEach(function (a) {
-                    if(a == user.department && course.audience!.type == Audience.Type.REQUIRED_LEARNING) {
-                        course.audience!.mandatory = true
-                    }
-                })
-            }
+			if (course.audience != null) {
+				course.audience!.mandatory = false
+				course.audience.departments.forEach(function (a) {
+					if (a == user.department && course.audience!.type == Audience.Type.REQUIRED_LEARNING) {
+						course.audience!.mandatory = true
+					}
+				})
+            		}
 		}
 
 		return course
@@ -347,7 +347,7 @@ export class Audience {
 		audience.interests = data.interests || []
 		audience.mandatory = data.mandatory === undefined ? true : data.mandatory
 		audience.frequency = data.frequency
-        audience.type = data.type
+		audience.type = data.type
 		if (data.requiredBy) {
 			audience.requiredBy = new Date(data.requiredBy)
 		}
@@ -361,7 +361,7 @@ export class Audience {
 	mandatory = false
 	requiredBy?: Date | null
 	frequency?: string
-    type: Audience.Type
+	type: Audience.Type
 
 	get optional() {
 		return !this.mandatory
@@ -434,13 +434,13 @@ export class Audience {
 	}
 }
 
-export namespace Audience{
-    export enum Type{
-        OPEN,
-        CLOSED_COURSE,
-        PRIVATE_COURSE,
-        REQUIRED_LEARNING
-    }
+export namespace Audience {
+	export enum Type {
+		OPEN,
+		CLOSED_COURSE,
+		PRIVATE_COURSE,
+		REQUIRED_LEARNING
+	}
 }
 
 export class Frequency {

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -34,12 +34,12 @@ export class Course {
 
 			if (course.audience != null) {
 				course.audience!.mandatory = false
-				course.audience.departments.forEach(function (a) {
-					if (a == user.department && course.audience!.type == Audience.Type.REQUIRED_LEARNING) {
+				course.audience.departments.forEach((a) => {
+					if (a === user.department && course.audience!.type === Audience.Type.REQUIRED_LEARNING) {
 						course.audience!.mandatory = true
 					}
 				})
-            		}
+			}
 		}
 
 		return course
@@ -436,11 +436,11 @@ export class Audience {
 
 export namespace Audience {
 	export enum Type {
-		OPEN,
-		CLOSED_COURSE,
-		PRIVATE_COURSE,
-		REQUIRED_LEARNING
-	}
+                OPEN,
+                CLOSED_COURSE,
+                PRIVATE_COURSE,
+                REQUIRED_LEARNING,
+        }
 }
 
 export class Frequency {

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -31,6 +31,15 @@ export class Course {
 				}
 			}
 			course.audience = matchedAudience
+
+            if(course.audience != null) {
+                course.audience!.mandatory = false
+                course.audience.departments.forEach(function (a) {
+                    if(a == user.department && course.audience!.type == Audience.Type.REQUIRED_LEARNING) {
+                        course.audience!.mandatory = true
+                    }
+                })
+            }
 		}
 
 		return course
@@ -338,6 +347,7 @@ export class Audience {
 		audience.interests = data.interests || []
 		audience.mandatory = data.mandatory === undefined ? true : data.mandatory
 		audience.frequency = data.frequency
+        audience.type = data.type
 		if (data.requiredBy) {
 			audience.requiredBy = new Date(data.requiredBy)
 		}
@@ -348,10 +358,10 @@ export class Audience {
 	departments: string[]
 	grades: string[]
 	interests: string[]
-	mandatory = true
-
+	mandatory = false
 	requiredBy?: Date | null
 	frequency?: string
+    type: Audience.Type
 
 	get optional() {
 		return !this.mandatory
@@ -422,6 +432,15 @@ export class Audience {
 		const lastDate = Frequency.decrement(this.frequency, nextDate)
 		return [lastDate, nextDate]
 	}
+}
+
+export namespace Audience{
+    export enum Type{
+        OPEN,
+        CLOSED_COURSE,
+        PRIVATE_COURSE,
+        REQUIRED_LEARNING
+    }
 }
 
 export class Frequency {


### PR DESCRIPTION
This is a fix that solves the issue of courses appearing as already in your learning plan when searching.

A courses audience is now set to mandatory base on the department of the current user and if the audience is of type 'Required Learning'.