### PR TITLE
LPFG-1011 duplicate IDs on search page

### DIFF
--- a/src/ui/component/LeftSearchBox.html
+++ b/src/ui/component/LeftSearchBox.html
@@ -1,6 +1,6 @@
 <aside role="complementary">
     <form autocomplete="off" name="searchLearning" method="get" action="/search">
-        <input type="hidden" id="q" name="q" value="{ query }" />
+        <input type="hidden" id="query" name="q" value="{ query }" />
         <div class="lpg-related-items form-group govuk-related-items--search leftSearchBox">
             <fieldset>
                 <legend>


### PR DESCRIPTION
Found 2 id's that shared the same name on the search results page (id="q"). Changed the id on a hidden input field in the search filters form to id="query". Tested that form and filters still work as expected.