### PR TITLE
Final access sweep

### DIFF
--- a/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
+++ b/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
@@ -18,11 +18,11 @@
 					target.setAttribute(
 						'class',
 						targetClass.replace(/(^|\s)js-visible(\s|$)/, ''),
-						(document.getElementById('visiblyHidden').innerHTML = 'expanded')
+						(document.getElementById('visiblyHidden').innerHTML = 'Select to expand')
 					)
 				} else {
 					target.setAttribute('class', targetClass + ' js-visible')
-					document.getElementById('visiblyHidden').innerHTML = 'Click to expand'
+					document.getElementById('visiblyHidden').innerHTML = 'Select to close'
 				}
 				if (sourceClass.indexOf('js-hidden') !== -1) {
 					this.setAttribute(

--- a/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
+++ b/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
@@ -18,11 +18,11 @@
 					target.setAttribute(
 						'class',
 						targetClass.replace(/(^|\s)js-visible(\s|$)/, ''),
-						(document.getElementById('visiblyHidden').innerHTML = 'Closed')
+						(document.getElementById('visiblyHidden').innerHTML = 'expanded')
 					)
 				} else {
 					target.setAttribute('class', targetClass + ' js-visible')
-					document.getElementById('visiblyHidden').innerHTML = 'Open'
+					document.getElementById('visiblyHidden').innerHTML = 'Click to expand'
 				}
 				if (sourceClass.indexOf('js-hidden') !== -1) {
 					this.setAttribute(

--- a/src/ui/assets/styles/common/_global.scss
+++ b/src/ui/assets/styles/common/_global.scss
@@ -90,6 +90,10 @@ hr.clear {
 	}
 }
 
+.description {
+	margin-top: 0;
+}
+
 .govuk-body {
 	font-size: 19px;
 	margin-top: 0;

--- a/src/ui/component/Header.html
+++ b/src/ui/component/Header.html
@@ -10,7 +10,7 @@
         </div>
         <div class="header-proposition">
             <div class="content">
-                <a href="#proposition-links" class="js-header-toggle menu">Menu <span class="visually-hidden" id="visiblyHidden">closed</span></a>
+                <a href="#proposition-links" class="js-header-toggle menu"><span class="visually-hidden" id="visiblyHidden">Select to expand</span> Menu</a>
                 <Nav/>
             </div>
         </div>

--- a/src/ui/page/course/blended.html
+++ b/src/ui/page/course/blended.html
@@ -5,6 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
+                 <h2 class="heading-medium">Course description</h2>
                 <div>{@html $toHtml(course.description)}</div>
 
                 {#if course.learningOutcomes}

--- a/src/ui/page/course/blended.html
+++ b/src/ui/page/course/blended.html
@@ -5,7 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
-                 <h2 class="heading-medium">Course description</h2>
+                <h2 class="description heading-medium">Overview</h2>
                 <div>{@html $toHtml(course.description)}</div>
 
                 {#if course.learningOutcomes}

--- a/src/ui/page/course/elearning.html
+++ b/src/ui/page/course/elearning.html
@@ -5,6 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
+                <h2 class="description heading-medium">Overview</h2>
                 <div>{@html $toHtml(course.description)}</div>
 
                 {#if course.learningOutcomes}

--- a/src/ui/page/course/face-to-face.html
+++ b/src/ui/page/course/face-to-face.html
@@ -5,6 +5,7 @@
     </h1>
     <div class="grid-row">
         <div class="column-two-thirds">
+            <h2 class="description heading-medium">Overview</h2>
             <div>{@html $toHtml(course.description)}</div>
 
             {#if course.learningOutcomes}

--- a/src/ui/page/course/file.html
+++ b/src/ui/page/course/file.html
@@ -5,6 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
+                <h2 class="description heading-medium">Overview</h2>
                 <div>{@html $toHtml(course.description)}</div>
 
                 {#if course.learningOutcomes}

--- a/src/ui/page/course/link.html
+++ b/src/ui/page/course/link.html
@@ -5,6 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
+                <h2 class="description heading-medium">Overview</h2>
                 <div>{@html $toHtml(course.description)}</div>
 
                 {#if course.learningOutcomes}

--- a/src/ui/page/course/video.html
+++ b/src/ui/page/course/video.html
@@ -5,6 +5,7 @@
         </h1>
         <div class="grid-row">
             <div class="column-two-thirds">
+                <h2 class="description heading-medium">Overview</h2>
                 <div>{@html $toHtml(course.description)}</div>
                 {#if course.learningOutcomes}
                 <h2 class="heading-medium">Learning outcomes</h2>

--- a/src/ui/page/profile/edit.html
+++ b/src/ui/page/profile/edit.html
@@ -3,19 +3,12 @@
         <div class="grid-row">
             <div class="{inputName === 'areas-of-work' ? 'column-full' : 'column-two-thirds' }">
                 {#if  ($i18n(inputName) === 'line-manager') }
-                    <h1 class="heading-large"><span class="heading-primary">Add your line manager's email</span></h1>
-                        <p class="govuk-body">To add a line manager, they must be registered with the service.</p>
-                    {:else}
-                        <h1 class="heading-large"><span class="heading-primary">Your {$i18n('profile_' + inputName + '_label').toLowerCase()}</span></h1>
-                    {/if}
-              
-                {#if lede}
-                    <p class="lede">
-                        {lede}
-                    </p>
+                <h1 class="heading-large"><span class="heading-primary">Add your line manager's email</span></h1>
+                    <p class="govuk-body">To add a line manager, they must be registered with the service.</p>
+                {:else}
+                    <h1 class="heading-large"><span class="heading-primary">Your {$i18n('profile_' + inputName + '_label').toLowerCase()}</span></h1>
                 {/if}
                 {#if (error || errorEmpty)}
-
                 <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
                     <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
                         Update failed


### PR DESCRIPTION
- Added enhanced user feedback for users of screenreader technology in the menu 
- Added Overview header for course info pages
- removed {lede} from profile edit page (this seems to have found its way back in via a merge?)