### PR TITLE
fix/booking-request-email

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -56,6 +56,7 @@ export const BOOKING_NOTIFY_TEMPLATE_IDS = {
 	cancelledLineManager: 'c00fac77-8448-41c9-b15c-23361ccef419',
 	confirmed: '8efb52bd-9ada-402e-8fab-84a751bf4a71',
 	confirmedLineManager: '659f8f61-d326-428e-996d-f890b61a2f96',
+	requested: 'ae678ea1-ae7a-42f3-aa27-037336b346c4',
 }
 
 export const BOOKING_NOTIFY_RECIPIENTS = [

--- a/src/lib/service/notify.ts
+++ b/src/lib/service/notify.ts
@@ -73,7 +73,7 @@ export async function bookingRequested(info: BookingConfirmation) {
 	const templateData = {...info}
 
 	await notify
-		.sendEmail(config.BOOKING_NOTIFY_TEMPLATE_IDS.confirmed, info.email, {
+		.sendEmail(config.BOOKING_NOTIFY_TEMPLATE_IDS.requested, info.email, {
 			personalisation: templateData,
 		})
 		.catch(reason => {


### PR DESCRIPTION
Added the booking requested email template, that template is now sent instead of the booking confirmed template when a learner books onto a course.