### PR TITLE
LPFG-1154 Booking without a line manager

### DIFF
--- a/src/ui/controllers/booking/booking.ts
+++ b/src/ui/controllers/booking/booking.ts
@@ -295,7 +295,7 @@ export async function renderPaymentOptions(
 			)) as any
 		}
 
-		if (!organisationalUnit) {
+		if (!organisationalUnit || !user.lineManager) {
 			res.redirect('/profile')
 		} else {
 			res.send(


### PR DESCRIPTION
If no line manager is set when trying to make a booking onto an event, the learner should be redirected to the profile page.