### PR TITLE
Feature empty handler for xapi learning locker

### DIFF
--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -171,6 +171,16 @@ app.param('eventId', asyncHandler(courseController.loadEvent))
 
 app.use('/courses/:proxyCourseId/:proxyModuleId/xapi', asyncHandler(xApiController.proxy))
 
+/**
+ * The below handler is added as there are xapi calls done against learning-record which were not handled and were
+ * caught by lusca CSRF check - resulting with big number of error messages.
+ *
+ * As it hit 100% error rate the below handler is proposed to remediate the errors appearing - it is to be
+ * investigated whether the calls should be handled (or could they be removed completely).
+ */
+app.use('/learning-record/:learnerRecordId/:notHandledModuleId/xapi',
+	(req: express.Request, res: express.Response) => res.sendStatus(204))
+
 app.use(lusca.csrf())
 
 app.get('/', homeController.index)


### PR DESCRIPTION
Adding an empty HTTP handler for xAPI e-learning statements. This should return HTTP 200, instead of 404s, and should reduce the volume of error logs the app throws.