### PR TITLE
Hotfix display duration 0 minutes

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -153,9 +153,10 @@ export class Course {
 			totalDuration += durationArray[i]
 		}
 
-		return durationArray.length
-			? datetime.formatCourseDuration(Number(totalDuration))
-			: null
+		if (durationArray.length > 0) {
+			return datetime.formatCourseDuration(Number(totalDuration))
+		}
+		return '0 minutes'
 	}
 
 	getGrades() {
@@ -370,7 +371,7 @@ export class Module {
 		}
 
 		if (!this.duration) {
-			return null
+			return '0 minutes'
 		}
 		return datetime.formatCourseDuration(this.duration)
 	}


### PR DESCRIPTION
This hot fix is to fix the duration field being empty in the home screen. If there are no modules or modules with no event duration we will display '0 minutes' instead of leaving it blank.