### PR TITLE
chore: ts warning

### DIFF
--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -105,6 +105,7 @@ async function unwrapPost(req: extended.CourseRequest) {
 	delete data['Content-Type']
 	delete data['X-Experience-API-Version']
 
+	// @ts-ignore
 	req.query = data
 
 	return req


### PR DESCRIPTION
- remove explicit cast ts warning