### PR TITLE
LC-14: refactoring change your email

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
 	"semi": false,
 	"singleQuote": true,
 	"trailingComma": "es5",
-	"useTabs": true
+	"useTabs": true,
+	"printWidth": 120
 }

--- a/src/lib/config/passport.ts
+++ b/src/lib/config/passport.ts
@@ -1,8 +1,8 @@
 import * as express from 'express'
-import * as config from "lib/config/index"
+import * as config from 'lib/config/index'
 import * as identity from 'lib/identity'
 import * as model from 'lib/model'
-import {ForceOrgChange} from "lib/model"
+import {ForceOrgChange} from 'lib/model'
 import * as registry from 'lib/registry'
 import * as log4js from 'log4js'
 import * as passport from 'passport'
@@ -29,12 +29,7 @@ export function configure(
 			clientSecret,
 			tokenURL: `${authenticationServiceUrl}/oauth/token`,
 		},
-		async (
-			accessToken: string,
-			refreshToken: string,
-			profile: any,
-			cb: oauth2.VerifyCallback
-		) => {
+		async (accessToken: string, refreshToken: string, profile: any, cb: oauth2.VerifyCallback) => {
 			profile.accessToken = accessToken
 
 			try {
@@ -67,7 +62,7 @@ export function configure(
 	passport.deserializeUser<model.User, string>(async (data, done) => {
 		let user: model.User
 		try {
-			user =  model.User.create(JSON.parse(data))
+			user = model.User.create(JSON.parse(data))
 			done(null, user)
 		} catch (error) {
 			done(error, undefined)
@@ -99,11 +94,7 @@ export function configure(
 	)
 }
 
-export function isAuthenticated(
-	req: express.Request,
-	res: express.Response,
-	next: express.NextFunction
-) {
+export function isAuthenticated(req: express.Request, res: express.Response, next: express.NextFunction) {
 	const authenticated = req.isAuthenticated()
 	if (authenticated) {
 		return next()
@@ -117,11 +108,7 @@ export function isAuthenticated(
 }
 
 export function hasRole(role: string) {
-	return (
-		req: express.Request,
-		res: express.Response,
-		next: express.NextFunction
-	) => {
+	return (req: express.Request, res: express.Response, next: express.NextFunction) => {
 		if (req.user && req.user.hasRole(role)) {
 			return next()
 		}
@@ -130,11 +117,7 @@ export function hasRole(role: string) {
 }
 
 export function hasAnyRole(roles: string[]) {
-	return (
-		req: express.Request,
-		res: express.Response,
-		next: express.NextFunction
-	) => {
+	return (req: express.Request, res: express.Response, next: express.NextFunction) => {
 		if (req.user && req.user.hasAnyRole(roles)) {
 			return next()
 		}

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -38,10 +38,7 @@ export class Course {
 			if (course.audience) {
 				course.audience.mandatory = false
 				course.audience.departments.forEach(a => {
-					if (
-						a === user.department &&
-						course.audience!.type === 'REQUIRED_LEARNING'
-					) {
+					if (a === user.department && course.audience!.type === 'REQUIRED_LEARNING') {
 						course.audience!.mandatory = true
 					}
 				})
@@ -109,9 +106,7 @@ export class Course {
 
 	getDuration() {
 		const durationArray = this.modules.map(m => m.duration)
-		return durationArray.length
-			? datetime.formatCourseDuration(durationArray.reduce((p, c) => p + c, 0))
-			: null
+		return durationArray.length ? datetime.formatCourseDuration(durationArray.reduce((p, c) => p + c, 0)) : null
 	}
 
 	getGrades() {
@@ -120,13 +115,9 @@ export class Course {
 
 	getSelectedDate() {
 		if (this.record) {
-			const bookedModuleRecord = this.record.modules.find(
-				m => !!m.eventId && m.state !== 'SKIPPED'
-			)
+			const bookedModuleRecord = this.record.modules.find(m => !!m.eventId && m.state !== 'SKIPPED')
 			if (bookedModuleRecord) {
-				const bookedModule = this.modules.find(
-					m => m.id === bookedModuleRecord.moduleId
-				)
+				const bookedModule = this.modules.find(m => m.id === bookedModuleRecord.moduleId)
 				if (bookedModule) {
 					const event = bookedModule.getEvent(bookedModuleRecord.eventId!)
 					if (event) {
@@ -178,10 +169,7 @@ export class Course {
 			for (const moduleRecord of this.record!.modules) {
 				if (!completionDate) {
 					completionDate = moduleRecord.completionDate
-				} else if (
-					moduleRecord.completionDate &&
-					moduleRecord.completionDate > completionDate
-				) {
+				} else if (moduleRecord.completionDate && moduleRecord.completionDate > completionDate) {
 					completionDate = moduleRecord.completionDate
 				}
 			}
@@ -283,9 +271,7 @@ export class Event {
 		// TODO: Matt - this is a temp work around to circumvent new event definition not matching UI
 		let date: any = ''
 		if (data.dateRanges[0]) {
-			date = new Date(
-				data.dateRanges[0].date + 'T' + data.dateRanges[0].startTime
-			)
+			date = new Date(data.dateRanges[0].date + 'T' + data.dateRanges[0].startTime)
 		} else {
 			date = data.date
 		}
@@ -315,14 +301,7 @@ export class Event {
 	status: string
 	isLearnerBooked: boolean
 
-	constructor(
-		date: Date,
-		location: string,
-		capacity: number,
-		availability: number,
-		status: string,
-		id?: string
-	) {
+	constructor(date: Date, location: string, capacity: number, availability: number, status: string, id?: string) {
 		if (id) {
 			this.id = id!
 		}
@@ -375,22 +354,11 @@ export class Audience {
 	getRelevance(user: User) {
 		let relevance = -1
 
-		if (
-			!(
-				this.areasOfWork.length ||
-				this.departments.length ||
-				this.grades.length
-			)
-		) {
+		if (!(this.areasOfWork.length || this.departments.length || this.grades.length)) {
 			return 0
 		}
 
-		if (
-			user.areasOfWork &&
-			this.areasOfWork.filter(
-				areaOfWork => user.areasOfWork!.indexOf(areaOfWork) > -1
-			).length
-		) {
+		if (user.areasOfWork && this.areasOfWork.filter(areaOfWork => user.areasOfWork!.indexOf(areaOfWork) > -1).length) {
 			relevance += 1
 		}
 		if (user.department && this.departments.indexOf(user.department) > -1) {
@@ -494,11 +462,8 @@ export class User {
 		} else {
 			user.forceOrgChange = new ForceOrgChange(false)
 		}
-		user.organisationalUnit =
-			data.organisationalUnit || new OrganisationalUnit()
-		user.department = data.organisationalUnit
-			? data.organisationalUnit.code
-			: data.department
+		user.organisationalUnit = data.organisationalUnit || new OrganisationalUnit()
+		user.department = data.organisationalUnit ? data.organisationalUnit.code : data.department
 		user.givenName = data.fullName ? data.fullName : data.givenName
 		user.grade = data.grade
 		if (data.profession || data.areasOfWork) {
@@ -538,13 +503,7 @@ export class User {
 
 	grade?: any
 
-	constructor(
-		id: string,
-		userName: string,
-		sessionIndex: string,
-		roles: string[],
-		accessToken: string
-	) {
+	constructor(id: string, userName: string, sessionIndex: string, roles: string[], accessToken: string) {
 		this.id = id
 		this.userName = userName
 		this.sessionIndex = sessionIndex

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -200,7 +200,7 @@ export async function patch(node: string, data: any, token: string) {
 			})
 			.patch(data, (error, response) => {
 				if (error) {
-					reject(false)
+					resolve(false)
 				} else {
 					if (response.statusCode >= 200 && response.statusCode < 300) {
 						resolve(true)

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,6 +1,7 @@
 import axios, {AxiosResponse} from 'axios'
 import * as https from "https"
 import * as config from 'lib/config'
+import {User} from "lib/model"
 import * as log4js from 'log4js'
 import * as traverson from 'traverson'
 import * as hal from 'traverson-hal'
@@ -123,11 +124,11 @@ export function getForceOrgResetFlag(token: string) {
 	return result
 }
 
-export function updateForceOrgResetFlag(token: string, data: any) {
+export function updateForceOrgResetFlag(user: User, data: any) {
 	const result = new Promise((resolve, reject) => {
 		httpCsrs
 			.patch(`/civilServants/org/reset`, data, {
-				headers: {Authorization: `Bearer ${token}`},
+				headers: {Authorization: `Bearer ${user.accessToken}`},
 			})
 			.then((response: any) => {
 				resolve(response)
@@ -155,8 +156,10 @@ export async function getOrgCode(token: string) {
 	return result
 }
 
-export async function getAgencyTokenByDomainAndOrgCode(token: string, domain: string, orgCode: string) {
-	const result = await new Promise((resolve, reject) => {
+export async function getAgencyTokenForUser(user: User, orgCode: string, domain: string) {
+	const token = user.accessToken
+
+	return await new Promise(resolve => {
 		httpCsrs
 			.get(`/agencyTokens?domain=${domain}&code=${orgCode}`, {
 				headers: {Authorization: `Bearer ${token}`},
@@ -168,10 +171,9 @@ export async function getAgencyTokenByDomainAndOrgCode(token: string, domain: st
 				resolve(error.response)
 			})
 	})
-	return result
 }
 
-export function updateAvailableSpacesOnAgencyToken(token: string, data: any) {
+export async function updateAvailableSpacesOnAgencyToken(token: string, data: any) {
 	const result = new Promise((resolve, reject) => {
 		httpCsrs
 			.put(`/agencyTokens`, data, {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,7 +1,7 @@
 import axios, {AxiosResponse} from 'axios'
-import * as https from "https"
+import * as https from 'https'
 import * as config from 'lib/config'
-import {User} from "lib/model"
+import {User} from 'lib/model'
 import * as log4js from 'log4js'
 import * as traverson from 'traverson'
 import * as hal from 'traverson-hal'
@@ -39,8 +39,9 @@ export async function get(node: string): Promise<{}> {
 			.jsonHal()
 			.follow(node, 'self')
 			.withRequestOptions({
-				qs: { size: 100, page: 0},
-			})			.getResource((error, document) => {
+				qs: {size: 100, page: 0},
+			})
+			.getResource((error, document) => {
 				if (error) {
 					reject(false)
 				} else {
@@ -57,11 +58,7 @@ export async function halNode(node: string): Promise<any[]> {
 	return (result as any)._embedded[node]
 }
 
-export async function follow(
-	path: string,
-	nodes: string[],
-	templateParameters?: any
-) {
+export async function follow(path: string, nodes: string[], templateParameters?: any) {
 	if (nodes.length === 0) {
 		nodes = ['self']
 	}
@@ -108,8 +105,8 @@ export async function checkLineManager(data: any, token: string) {
 	return result
 }
 
-export function getForceOrgResetFlag(token: string) {
-	const result = new Promise<boolean>((resolve, reject) => {
+export async function getForceOrgResetFlag(token: string) {
+	const result = await new Promise<boolean>((resolve, reject) => {
 		httpCsrs
 			.get(`/civilServants/org/reset`, {
 				headers: {Authorization: `Bearer ${token}`},
@@ -124,8 +121,8 @@ export function getForceOrgResetFlag(token: string) {
 	return result
 }
 
-export function updateForceOrgResetFlag(user: User, data: any) {
-	const result = new Promise((resolve, reject) => {
+export async function updateForceOrgResetFlag(user: User, data: any) {
+	const result = await new Promise((resolve, reject) => {
 		httpCsrs
 			.patch(`/civilServants/org/reset`, data, {
 				headers: {Authorization: `Bearer ${user.accessToken}`},
@@ -240,23 +237,21 @@ export async function profile(token: string) {
 export async function getWithoutHal(path: string): Promise<AxiosResponse> {
 	try {
 		return await http.get(config.REGISTRY_SERVICE_URL + path)
-	}	catch (error) {
+	} catch (error) {
 		throw new Error(error)
 	}
 }
 
-export async function isTokenizedUser(
-	code: string,
-	domain: string
-) {
-
-		let tokenziedUser = false
-		await http.get(config.REGISTRY_SERVICE_URL + `/agencyTokens`, {
+export async function isTokenizedUser(code: string, domain: string) {
+	let tokenziedUser = false
+	await http
+		.get(config.REGISTRY_SERVICE_URL + `/agencyTokens`, {
 			params: {
 				code,
 				domain,
 			},
-		}).then(e => {
+		})
+		.then(e => {
 			if (e.status === 200) {
 				tokenziedUser = true
 			} else {
@@ -264,29 +259,26 @@ export async function isTokenizedUser(
 			}
 		})
 
-		return tokenziedUser
-	}
+	return tokenziedUser
+}
 
-export async function isValidToken(
-		code: string,
-		domain: string,
-		token: string
-) {
-
+export async function isValidToken(code: string, domain: string, token: string) {
 	let validToken = false
-	await http.get(config.REGISTRY_SERVICE_URL + `/agencyTokens`, {
-		params: {
-			code,
-			domain,
-			token,
-		},
-	}).then(e => {
-		if (e.status === 200) {
-			validToken = true
-		} else {
-			validToken = false
-		}
-	})
+	await http
+		.get(config.REGISTRY_SERVICE_URL + `/agencyTokens`, {
+			params: {
+				code,
+				domain,
+				token,
+			},
+		})
+		.then(e => {
+			if (e.status === 200) {
+				validToken = true
+			} else {
+				validToken = false
+			}
+		})
 	return validToken
 }
 
@@ -297,7 +289,6 @@ export async function updateToken(
 	removeUser: boolean,
 	accessToken: string
 ) {
-
 	const data = JSON.stringify({
 		code,
 		domain,
@@ -307,15 +298,15 @@ export async function updateToken(
 
 	const result = new Promise((resolve, reject) => {
 		httpCsrs
-		.put(config.REGISTRY_SERVICE_URL + `/agencyTokens`, data, {
-			headers: {Authorization: `Bearer ${accessToken}`},
-		})
-		.then((response: any) => {
-			resolve(response)
-		})
-		.catch((error: any) => {
-			resolve(error.response)
-		})
+			.put(config.REGISTRY_SERVICE_URL + `/agencyTokens`, data, {
+				headers: {Authorization: `Bearer ${accessToken}`},
+			})
+			.then((response: any) => {
+				resolve(response)
+			})
+			.catch((error: any) => {
+				resolve(error.response)
+			})
 	})
 	return result
 }

--- a/src/lib/ui/profileChecker.ts
+++ b/src/lib/ui/profileChecker.ts
@@ -13,11 +13,13 @@ export class ProfileChecker {
 			return Boolean(user.givenName)
 		}),
 		new ProfileSection('organisationalUnit', '/profile/organisation', (user: User) => {
-			// tslint:disable-next-line:max-line-length
-			return (Boolean (!user.forceOrgChange.isForceOrgChange()) && (Boolean(user.organisationalUnit &&  user.organisationalUnit.name)))
+			return (
+				Boolean(!user.forceOrgChange.isForceOrgChange()) &&
+				Boolean(user.organisationalUnit && user.organisationalUnit.name)
+			)
 		}),
 		new ProfileSection('department', '/profile/organisation', (user: User) => {
-			return (Boolean (!user.forceOrgChange.isForceOrgChange()) && (Boolean(user.department)))
+			return Boolean(!user.forceOrgChange.isForceOrgChange()) && Boolean(user.department)
 		}),
 		new ProfileSection('areasOfWork', '/profile/profession', (user: User) => {
 			return Boolean(user.areasOfWork && user.areasOfWork.length)
@@ -27,26 +29,28 @@ export class ProfileChecker {
 		}),
 	]
 	isProfileRequest(request: Request) {
-		return Boolean(this._profileSections.filter(entry => {
-			return entry.path === request.path
-		}).length)
+		return Boolean(
+			this._profileSections.filter(entry => {
+				return entry.path === request.path
+			}).length
+		)
 	}
 	checkProfile() {
-		return 	(request: Request, response: Response, next: NextFunction) => {
+		return (request: Request, response: Response, next: NextFunction) => {
 			if (!this.isProfileRequest(request)) {
-					try {
-						for (const section of this._profileSections) {
-							if (!section.isPresent(request.user)) {
-								request.session!.save(() => {
-									response.redirect(`${section.path}?originalUrl=${request.originalUrl}`)
-								})
-								return
-							}
+				try {
+					for (const section of this._profileSections) {
+						if (!section.isPresent(request.user)) {
+							request.session!.save(() => {
+								response.redirect(`${section.path}?originalUrl=${request.originalUrl}`)
+							})
+							return
 						}
-					}	catch (error) {
-						logger.error(error)
-						next(error)
 					}
+				} catch (error) {
+					logger.error(error)
+					next(error)
+				}
 			}
 
 			next()

--- a/src/ui/component/ProfileEditForm.html
+++ b/src/ui/component/ProfileEditForm.html
@@ -7,9 +7,7 @@
     {/if}
     <div class="form-group">
         {#if options && options.length }
-
             <Selects {options} {optionType} {inputName} label="{$i18n('profile_' + inputName + '_label')}" {value} {lede} />
-
         {:else}
             <label class="form-label" for="{inputName}">New {$i18n('profile_' + inputName + '_label').toLowerCase()}</label>
             <input class="form-control" id="{inputName}" name="{inputName}" value="{value || ''}" type="{inputName === 'password' ? 'password' :'text'}">

--- a/src/ui/controllers/profile.ts
+++ b/src/ui/controllers/profile.ts
@@ -1,5 +1,5 @@
 import {IsEmail, IsNotEmpty, validate} from 'class-validator'
-import {NextFunction, Request, Response} from 'express'
+import {Request, Response} from 'express'
 import * as config from 'lib/config'
 import {ForceOrgChange, User} from 'lib/model'
 import * as _ from 'lodash'
@@ -50,9 +50,7 @@ export async function updateName(request: Request, response: Response) {
 		setLocalProfile(request, 'givenName', name)
 
 		request.session!.save(() =>
-			response.redirect(
-				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
-			)
+			response.redirect(request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl)
 		)
 	}
 }
@@ -61,9 +59,7 @@ export async function addOrganisation(request: Request, response: Response) {
 	const options: {[prop: string]: any} = {}
 	const email = request.user.userName
 	const domain = email.split('@')[1]
-	const organisations: any = await registry.getWithoutHal(
-		'/organisationalUnits/flat/' + domain + '/'
-	)
+	const organisations: any = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
 	organisations.data.map((x: any) => {
 		options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
 	})
@@ -85,13 +81,10 @@ export async function updateOrganisation(request: Request, response: Response) {
 	const value = request.body.organisation
 	const email = request.user.userName
 	const domain = email.split('@')[1]
-
 	if (!value) {
 		const options: {[prop: string]: any} = {}
 
-		const organisations: any = await registry.getWithoutHal(
-			'/organisationalUnits/flat/' + domain + '/'
-		)
+		const organisations: any = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
 		organisations.data.map((x: any) => {
 			options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
 		})
@@ -123,11 +116,7 @@ export async function updateOrganisation(request: Request, response: Response) {
 	}
 
 	try {
-		await registry.patch(
-			'civilServants',
-			{organisationalUnit: request.body.organisation},
-			request.user.accessToken
-		)
+		await registry.patch('civilServants', {organisationalUnit: request.body.organisation}, request.user.accessToken)
 	} catch (error) {
 		console.log(error)
 		throw new Error(error)
@@ -147,11 +136,9 @@ export async function updateOrganisation(request: Request, response: Response) {
 		setLocalProfile(request, 'department', organisationalUnit.code)
 		setLocalProfile(request, 'organisationalUnit', organisationalUnit)
 		setLocalProfile(request, 'forceOrgChange', new ForceOrgChange(false))
-
+		logger.info(request.user)
 		request.session!.save(() =>
-			response.redirect(
-				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
-			)
+			response.redirect(request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl)
 		)
 	} else {
 		throw new Error(res)
@@ -191,9 +178,7 @@ export async function updateProfession(request: Request, response: Response) {
 			})
 		)
 	} else {
-		const professionsTree: any = await registry.getWithoutHal(
-			'/professions/tree'
-		)
+		const professionsTree: any = await registry.getWithoutHal('/professions/tree')
 		const options: any = sortList(professionsTree.data)
 		let children: any = []
 
@@ -213,9 +198,7 @@ export async function updateProfession(request: Request, response: Response) {
 		if (children.length > 0) {
 			request.session!.flash = {children}
 			return request.session!.save(() => {
-				response.redirect(
-					`/profile/profession?originalUrl=${request.body.originalUrl}`
-				)
+				response.redirect(`/profile/profession?originalUrl=${request.body.originalUrl}`)
 			})
 		}
 		if (request.session!.flash && request.session!.flash.children) {
@@ -234,9 +217,7 @@ export async function updateProfession(request: Request, response: Response) {
 		}
 
 		try {
-			const professionResponse: any = await registry.getWithoutHal(
-				profession.replace(config.REGISTRY_SERVICE_URL, '')
-			)
+			const professionResponse: any = await registry.getWithoutHal(profession.replace(config.REGISTRY_SERVICE_URL, ''))
 			const data = professionResponse.data
 
 			setLocalProfile(request, 'areasOfWork', [data.id, data.name])
@@ -246,17 +227,12 @@ export async function updateProfession(request: Request, response: Response) {
 		}
 
 		request.session!.save(() =>
-			response.redirect(
-				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
-			)
+			response.redirect(request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl)
 		)
 	}
 }
 
-export async function addOtherAreasOfWork(
-	request: Request,
-	response: Response
-) {
+export async function addOtherAreasOfWork(request: Request, response: Response) {
 	const professionsTree: any = await registry.getWithoutHal('/professions/tree')
 	const professions = sortList(professionsTree.data)
 	response.send(
@@ -267,10 +243,7 @@ export async function addOtherAreasOfWork(
 	)
 }
 
-export async function updateOtherAreasOfWork(
-	request: Request,
-	response: Response
-) {
+export async function updateOtherAreasOfWork(request: Request, response: Response) {
 	const otherAreasOfWork = request.body.otherAreasOfWork
 
 	if (!otherAreasOfWork) {
@@ -315,11 +288,7 @@ export async function updateOtherAreasOfWork(
 			throw new Error(error)
 		}
 
-		request.session!.save(() =>
-			response.redirect(
-				`/profile/interests?originalUrl=${request.body.originalUrl}`
-			)
-		)
+		request.session!.save(() => response.redirect(`/profile/interests?originalUrl=${request.body.originalUrl}`))
 	}
 }
 
@@ -354,9 +323,7 @@ export async function updateInterests(request: Request, response: Response) {
 		try {
 			const updatedInterests = []
 			for (const interest of values) {
-				const interestResponse: any = await registry.getWithoutHal(
-					interest.replace(config.REGISTRY_SERVICE_URL, '')
-				)
+				const interestResponse: any = await registry.getWithoutHal(interest.replace(config.REGISTRY_SERVICE_URL, ''))
 				updatedInterests.push({name: interestResponse.data.name})
 			}
 			setLocalProfile(request, 'interests', updatedInterests)
@@ -365,9 +332,7 @@ export async function updateInterests(request: Request, response: Response) {
 			throw new Error(error)
 		}
 	}
-	request.session!.save(() =>
-		response.redirect(`/profile/grade?originalUrl=${request.body.originalUrl}`)
-	)
+	request.session!.save(() => response.redirect(`/profile/grade?originalUrl=${request.body.originalUrl}`))
 }
 
 export async function addGrade(request: Request, response: Response) {
@@ -399,9 +364,7 @@ export async function updateGrade(request: Request, response: Response) {
 		}
 
 		try {
-			const gradeResponse: any = await registry.getWithoutHal(
-				grade.replace(config.REGISTRY_SERVICE_URL, '')
-			)
+			const gradeResponse: any = await registry.getWithoutHal(grade.replace(config.REGISTRY_SERVICE_URL, ''))
 			setLocalProfile(request, 'grade', {
 				code: gradeResponse.data.code,
 				name: gradeResponse.data.name,
@@ -411,11 +374,7 @@ export async function updateGrade(request: Request, response: Response) {
 			throw new Error(error)
 		}
 	}
-	request.session!.save(() =>
-		response.redirect(
-			`/profile/lineManager?originalUrl=${request.body.originalUrl}`
-		)
-	)
+	request.session!.save(() => response.redirect(`/profile/lineManager?originalUrl=${request.body.originalUrl}`))
 }
 
 export function addLineManager(request: Request, response: Response) {
@@ -443,10 +402,7 @@ export async function updateLineManager(request: Request, response: Response) {
 			)
 			return
 		}
-		const res: any = await registry.checkLineManager(
-			{lineManager: lineManager.email},
-			request.user.accessToken
-		)
+		const res: any = await registry.checkLineManager({lineManager: lineManager.email}, request.user.accessToken)
 		if (res.status === 404) {
 			errors.push('errors.lineManagerMissing')
 
@@ -481,66 +437,52 @@ export async function updateLineManager(request: Request, response: Response) {
 	}
 
 	request.session!.save(() =>
-		response.redirect(
-			request.body.originalUrl !== 'undefined'
-				? request.body.originalUrl
-				: defaultRedirectUrl
-		)
+		response.redirect(request.body.originalUrl !== 'undefined' ? request.body.originalUrl : defaultRedirectUrl)
 	)
 }
 
 export function addEmail(request: Request, response: Response) {
-	// original url is not required as email is not part of Profile Checker
 	response.send(template.render('profile/email', request, response))
 }
 
-export async function updateEmail(
-	request: Request,
-	response: Response,
-	next: NextFunction
-) {
+/**
+ * This method sends the user to the update email form on Identity.
+ * Before doing so it needs to check if it is part of an agency token and if so, update token quota.
+ * For all users, set a flag on their civil servant object in csrs, to force organisation to be set next on log in.
+ * Clear any local profile info for dept/org.
+ *
+ * @param {Request} request
+ * @param {Response} response
+ * @returns response.redirect to change email form on Identity
+ */
+export async function updateEmail(request: Request, response: Response) {
 	try {
 		const agencyTokenFactory: AgencyTokenFactory = new AgencyTokenFactory()
 		const user = request.user
 		const email = user.userName
 		const oldDomain = email.split('@')[1]
+
 		if (
-			_.isEmpty(user.organisationalUnit) ||
-			user.organisationalUnit === undefined ||
-			user.organisationalUnit.code === undefined
+			!_.isEmpty(user.organisationalUnit) &&
+			user.organisationalUnit !== undefined &&
+			user.organisationalUnit.code !== undefined
 		) {
-			logger.debug(
-				`User ${
-					user.id
-				} does not have org code. Cannot validate, so sending them to change email form`
-			)
-			return request.session!.save(() =>
-				response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
-			)
+			const value: any = await registry.getAgencyTokenForUser(user, user.organisationalUnit.code, oldDomain)
+			if (value.status === 200) {
+				logger.debug(`User ${user.id} is an agency user. Adjusting token quota`)
+				const agencyToken = agencyTokenFactory.create(value.data)
+				await adjustTokenQuota(user, agencyToken, oldDomain)
+			}
 		}
 
-		const value: any = await registry.getAgencyTokenForUser(user, user.organisationalUnit.code, oldDomain)
-		if (value.status === 404) {
-			logger.debug(`User ${user.id} does not agency token. Sending them to change email form`)
-			return response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
-		}
-		const agencyToken = agencyTokenFactory.create(value.data)
-		await adjustTokenQuota(user, agencyToken, oldDomain)
 		const dto = {forceOrgChange: true}
 		const res: any = await registry.updateForceOrgResetFlag(user, dto)
 		if (res.status === 204) {
 			setLocalProfile(request, 'department', null)
 			setLocalProfile(request, 'organisationalUnit', null)
 			setLocalProfile(request, 'forceOrgChange', true)
-			logger.info(
-				'Org updated, redirecting to ' +
-					config.AUTHENTICATION.serviceUrl +
-					'/account/email'
-			)
 
-			return request.session!.save(() =>
-				response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
-			)
+			return request.session!.save(() => response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email'))
 		}
 	} catch (error) {
 		logger.error(error)
@@ -579,11 +521,7 @@ function setLocalProfile(request: Request, key: string, value: any) {
 	request.session!.save(() => {})
 }
 
-async function adjustTokenQuota(
-	user: User,
-	agencyToken: AgencyToken,
-	oldDomain: string
-) {
+async function adjustTokenQuota(user: User, agencyToken: AgencyToken, oldDomain: string) {
 	const quotaDTO = {
 		code: user.organisationalUnit!.code,
 		domain: oldDomain,

--- a/src/ui/controllers/profile.ts
+++ b/src/ui/controllers/profile.ts
@@ -1,12 +1,13 @@
 import {IsEmail, IsNotEmpty, validate} from 'class-validator'
-import {Request, Response} from 'express'
+import {NextFunction, Request, Response} from 'express'
 import * as config from 'lib/config'
-import * as identity from 'lib/identity'
-import {ForceOrgChange} from "lib/model"
+import {ForceOrgChange, User} from 'lib/model'
 import * as _ from 'lodash'
 import * as log4js from 'log4js'
 import * as registry from '../../lib/registry'
 import * as template from '../../lib/ui/template'
+import {AgencyTokenFactory} from '../factory/agencyTokenFactory'
+import {AgencyToken} from '../model/agencyToken'
 
 log4js.configure(config.LOGGING)
 const logger = log4js.getLogger('profile')
@@ -14,25 +15,33 @@ const logger = log4js.getLogger('profile')
 const defaultRedirectUrl = '/home'
 
 export function addName(request: Request, response: Response) {
-	response.send(template.render('profile/name', request, response, {
-		originalUrl: request.query.originalUrl,
-	}))
+	response.send(
+		template.render('profile/name', request, response, {
+			originalUrl: request.query.originalUrl,
+		})
+	)
 }
 
 export async function updateName(request: Request, response: Response) {
 	const name = request.body.name
 
 	if (!name) {
-		response.send(template.render('profile/name', request, response, {
-			error: true,
-			name,
-			originalUrl: request.body.originalUrl,
-		}))
+		response.send(
+			template.render('profile/name', request, response, {
+				error: true,
+				name,
+				originalUrl: request.body.originalUrl,
+			})
+		)
 	} else {
 		try {
-			await registry.patch('civilServants', {
-				fullName: request.body.name,
-			}, request.user.accessToken)
+			await registry.patch(
+				'civilServants',
+				{
+					fullName: request.body.name,
+				},
+				request.user.accessToken
+			)
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)
@@ -41,53 +50,62 @@ export async function updateName(request: Request, response: Response) {
 		setLocalProfile(request, 'givenName', name)
 
 		request.session!.save(() =>
-			response.redirect((request.body.originalUrl) ? request.body.originalUrl : defaultRedirectUrl)
+			response.redirect(
+				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
+			)
 		)
 	}
 }
 
 export async function addOrganisation(request: Request, response: Response) {
-	const options: { [prop: string]: any } = {}
+	const options: {[prop: string]: any} = {}
 	const email = request.user.userName
-	const domain = email.split("@")[1]
-	const organisations: any = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
+	const domain = email.split('@')[1]
+	const organisations: any = await registry.getWithoutHal(
+		'/organisationalUnits/flat/' + domain + '/'
+	)
 	organisations.data.map((x: any) => {
 		options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
 	})
 
 	const value = request.user.department
 
-	response.send(template.render('profile/organisation', request, response, {
-		inputName: 'organisation',
-		label: 'Organisation',
-		options: Object.entries(options),
-		originalUrl: request.query.originalUrl,
-		value,
-	}))
+	response.send(
+		template.render('profile/organisation', request, response, {
+			inputName: 'organisation',
+			label: 'Organisation',
+			options: Object.entries(options),
+			originalUrl: request.query.originalUrl,
+			value,
+		})
+	)
 }
 
 export async function updateOrganisation(request: Request, response: Response) {
-
 	const value = request.body.organisation
 	const email = request.user.userName
-	const domain = email.split("@")[1]
+	const domain = email.split('@')[1]
 
 	if (!value) {
-		const options: { [prop: string]: any } = {}
+		const options: {[prop: string]: any} = {}
 
-		const organisations: any = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
+		const organisations: any = await registry.getWithoutHal(
+			'/organisationalUnits/flat/' + domain + '/'
+		)
 		organisations.data.map((x: any) => {
 			options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
 		})
 
-		response.send(template.render('profile/organisation', request, response, {
-			error: true,
-			inputName: 'organisation',
-			label: 'Organisation',
-			options: Object.entries(options),
-			originalUrl: request.body.originalUrl,
-			value,
-		}))
+		response.send(
+			template.render('profile/organisation', request, response, {
+				error: true,
+				inputName: 'organisation',
+				label: 'Organisation',
+				options: Object.entries(options),
+				originalUrl: request.body.originalUrl,
+				value,
+			})
+		)
 	}
 
 	let organisationalUnit
@@ -105,30 +123,35 @@ export async function updateOrganisation(request: Request, response: Response) {
 	}
 
 	try {
-		await registry.patch('civilServants', {organisationalUnit: request.body.organisation, }, request.user.accessToken)
+		await registry.patch(
+			'civilServants',
+			{organisationalUnit: request.body.organisation},
+			request.user.accessToken
+		)
 	} catch (error) {
-			console.log(error)
-			throw new Error(error)
+		console.log(error)
+		throw new Error(error)
 	}
 
 	let res: any
 	const dto = {forceOrgChange: false}
 
 	try {
-		res = await registry.updateForceOrgResetFlag(request.user.accessToken, dto)
+		res = await registry.updateForceOrgResetFlag(request.user, dto)
 	} catch (error) {
 		console.log(error)
 		throw new Error(error)
 	}
 
 	if (res.status === 204) {
-
 		setLocalProfile(request, 'department', organisationalUnit.code)
 		setLocalProfile(request, 'organisationalUnit', organisationalUnit)
 		setLocalProfile(request, 'forceOrgChange', new ForceOrgChange(false))
 
 		request.session!.save(() =>
-				response.redirect((request.body.originalUrl) ? request.body.originalUrl : defaultRedirectUrl)
+			response.redirect(
+				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
+			)
 		)
 	} else {
 		throw new Error(res)
@@ -136,8 +159,7 @@ export async function updateOrganisation(request: Request, response: Response) {
 }
 
 export async function addProfession(request: Request, response: Response) {
-
-	let options: { [prop: string]: any }
+	let options: {[prop: string]: any}
 	let res: any
 
 	if (request.session!.flash && request.session!.flash.children) {
@@ -147,10 +169,11 @@ export async function addProfession(request: Request, response: Response) {
 		options = sortList(res.data)
 	}
 
-	response.send(template.render('profile/profession', request, response, {
-				originalUrl: request.query.originalUrl,
-				professions: Object.entries(options),
-			})
+	response.send(
+		template.render('profile/profession', request, response, {
+			originalUrl: request.query.originalUrl,
+			professions: Object.entries(options),
+		})
 	)
 }
 
@@ -158,19 +181,23 @@ export async function updateProfession(request: Request, response: Response) {
 	const profession = request.body.profession
 
 	if (!profession) {
-		const professions = await getOptions("professions")
-		response.send(template.render('profile/profession', request, response, {
-			error: true,
-			originalUrl: request.body.originalUrl,
-			profession,
-			professions,
-		}))
+		const professions = await getOptions('professions')
+		response.send(
+			template.render('profile/profession', request, response, {
+				error: true,
+				originalUrl: request.body.originalUrl,
+				profession,
+				professions,
+			})
+		)
 	} else {
-		const professionsTree: any = await registry.getWithoutHal('/professions/tree')
+		const professionsTree: any = await registry.getWithoutHal(
+			'/professions/tree'
+		)
 		const options: any = sortList(professionsTree.data)
 		let children: any = []
 
-		const areaOfWorkId = profession.split("/professions/").pop()
+		const areaOfWorkId = profession.split('/professions/').pop()
 		options.forEach((option: any) => {
 			option.children.forEach((child: any) => {
 				// tslint:disable-next-line
@@ -186,22 +213,30 @@ export async function updateProfession(request: Request, response: Response) {
 		if (children.length > 0) {
 			request.session!.flash = {children}
 			return request.session!.save(() => {
-				response.redirect(`/profile/profession?originalUrl=${request.body.originalUrl}`)
+				response.redirect(
+					`/profile/profession?originalUrl=${request.body.originalUrl}`
+				)
 			})
 		}
 		if (request.session!.flash && request.session!.flash.children) {
 			delete request.session!.flash.children
 		}
 		try {
-			await registry.patch('civilServants', {
-				profession,
-			}, request.user.accessToken)
+			await registry.patch(
+				'civilServants',
+				{
+					profession,
+				},
+				request.user.accessToken
+			)
 		} catch (error) {
 			throw new Error(error)
 		}
 
 		try {
-			const professionResponse: any = await registry.getWithoutHal(profession.replace(config.REGISTRY_SERVICE_URL, ''))
+			const professionResponse: any = await registry.getWithoutHal(
+				profession.replace(config.REGISTRY_SERVICE_URL, '')
+			)
 			const data = professionResponse.data
 
 			setLocalProfile(request, 'areasOfWork', [data.id, data.name])
@@ -211,38 +246,54 @@ export async function updateProfession(request: Request, response: Response) {
 		}
 
 		request.session!.save(() =>
-				response.redirect((request.body.originalUrl) ? request.body.originalUrl : defaultRedirectUrl)
+			response.redirect(
+				request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl
+			)
 		)
 	}
 }
 
-export async function addOtherAreasOfWork(request: Request, response: Response) {
+export async function addOtherAreasOfWork(
+	request: Request,
+	response: Response
+) {
 	const professionsTree: any = await registry.getWithoutHal('/professions/tree')
 	const professions = sortList(professionsTree.data)
-	response.send(template.render('profile/otherAreasOfWork', request, response, {
-		originalUrl: request.query.originalUrl,
-		professions,
-	}))
+	response.send(
+		template.render('profile/otherAreasOfWork', request, response, {
+			originalUrl: request.query.originalUrl,
+			professions,
+		})
+	)
 }
 
-export async function updateOtherAreasOfWork(request: Request, response: Response) {
+export async function updateOtherAreasOfWork(
+	request: Request,
+	response: Response
+) {
 	const otherAreasOfWork = request.body.otherAreasOfWork
 
 	if (!otherAreasOfWork) {
-		const professions = await getOptions("professions")
-		response.send(template.render('profile/otherAreasOfWork', request, response, {
-			error: true,
-			originalUrl: request.body.originalUrl,
-			professions,
-		}))
+		const professions = await getOptions('professions')
+		response.send(
+			template.render('profile/otherAreasOfWork', request, response, {
+				error: true,
+				originalUrl: request.body.originalUrl,
+				professions,
+			})
+		)
 	} else {
 		const values: string[] = [].concat(otherAreasOfWork).map(value => {
-			return "/professions/" + value
+			return '/professions/' + value
 		})
 		try {
-			await registry.patch('civilServants', {
-				otherAreasOfWork: values,
-			}, request.user.accessToken)
+			await registry.patch(
+				'civilServants',
+				{
+					otherAreasOfWork: values,
+				},
+				request.user.accessToken
+			)
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)
@@ -252,7 +303,10 @@ export async function updateOtherAreasOfWork(request: Request, response: Respons
 			const professions = []
 			for (const profession of values) {
 				const professionResponse: any = await registry.getWithoutHal(profession)
-				professions.push({id: professionResponse.data.id, name: professionResponse.data.name})
+				professions.push({
+					id: professionResponse.data.id,
+					name: professionResponse.data.name,
+				})
 			}
 
 			setLocalProfile(request, 'otherAreasOfWork', professions)
@@ -262,17 +316,21 @@ export async function updateOtherAreasOfWork(request: Request, response: Respons
 		}
 
 		request.session!.save(() =>
-				response.redirect(`/profile/interests?originalUrl=${request.body.originalUrl}`)
+			response.redirect(
+				`/profile/interests?originalUrl=${request.body.originalUrl}`
+			)
 		)
 	}
 }
 
 export async function addInterests(request: Request, response: Response) {
-	const interests = await getOptions("interests")
-	response.send(template.render('profile/interests', request, response, {
-		interests,
-		originalUrl: request.query.originalUrl,
-	}))
+	const interests = await getOptions('interests')
+	response.send(
+		template.render('profile/interests', request, response, {
+			interests,
+			originalUrl: request.query.originalUrl,
+		})
+	)
 }
 
 export async function updateInterests(request: Request, response: Response) {
@@ -281,9 +339,13 @@ export async function updateInterests(request: Request, response: Response) {
 	if (interests) {
 		const values: string[] = [].concat(interests)
 		try {
-			await registry.patch('civilServants', {
-				interests: values,
-			}, request.user.accessToken)
+			await registry.patch(
+				'civilServants',
+				{
+					interests: values,
+				},
+				request.user.accessToken
+			)
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)
@@ -292,7 +354,9 @@ export async function updateInterests(request: Request, response: Response) {
 		try {
 			const updatedInterests = []
 			for (const interest of values) {
-				const interestResponse: any = await registry.getWithoutHal(interest.replace(config.REGISTRY_SERVICE_URL, ''))
+				const interestResponse: any = await registry.getWithoutHal(
+					interest.replace(config.REGISTRY_SERVICE_URL, '')
+				)
 				updatedInterests.push({name: interestResponse.data.name})
 			}
 			setLocalProfile(request, 'interests', updatedInterests)
@@ -302,16 +366,18 @@ export async function updateInterests(request: Request, response: Response) {
 		}
 	}
 	request.session!.save(() =>
-			response.redirect(`/profile/grade?originalUrl=${request.body.originalUrl}`)
+		response.redirect(`/profile/grade?originalUrl=${request.body.originalUrl}`)
 	)
 }
 
 export async function addGrade(request: Request, response: Response) {
 	const grades = await getOptions('grades')
-	response.send(template.render('profile/grade', request, response, {
-		grades,
-		originalUrl: request.query.originalUrl,
-	}))
+	response.send(
+		template.render('profile/grade', request, response, {
+			grades,
+			originalUrl: request.query.originalUrl,
+		})
+	)
 }
 
 export async function updateGrade(request: Request, response: Response) {
@@ -319,32 +385,45 @@ export async function updateGrade(request: Request, response: Response) {
 
 	if (grade) {
 		try {
-			await registry.patch('civilServants', {
-				grade,
-				originalUrl: request.body.originalUrl,
-			}, request.user.accessToken)
+			await registry.patch(
+				'civilServants',
+				{
+					grade,
+					originalUrl: request.body.originalUrl,
+				},
+				request.user.accessToken
+			)
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)
 		}
 
 		try {
-			const gradeResponse: any = await registry.getWithoutHal(grade.replace(config.REGISTRY_SERVICE_URL, ''))
-			setLocalProfile(request, 'grade', {code: gradeResponse.data.code, name: gradeResponse.data.name})
+			const gradeResponse: any = await registry.getWithoutHal(
+				grade.replace(config.REGISTRY_SERVICE_URL, '')
+			)
+			setLocalProfile(request, 'grade', {
+				code: gradeResponse.data.code,
+				name: gradeResponse.data.name,
+			})
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)
 		}
 	}
 	request.session!.save(() =>
-			response.redirect(`/profile/lineManager?originalUrl=${request.body.originalUrl}`)
+		response.redirect(
+			`/profile/lineManager?originalUrl=${request.body.originalUrl}`
+		)
 	)
 }
 
 export function addLineManager(request: Request, response: Response) {
-	response.send(template.render('profile/lineManager', request, response, {
-		originalUrl: request.query.originalUrl,
-	}))
+	response.send(
+		template.render('profile/lineManager', request, response, {
+			originalUrl: request.query.originalUrl,
+		})
+	)
 }
 
 export async function updateLineManager(request: Request, response: Response) {
@@ -354,34 +433,43 @@ export async function updateLineManager(request: Request, response: Response) {
 		const errors = await lineManager.validate()
 
 		if (errors.length) {
-			response.send(template.render('profile/lineManager', request, response, {
-				confirm: lineManager.confirm,
-				email: lineManager.email,
-				errors,
-				originalUrl: request.body.originalUrl,
-			}))
+			response.send(
+				template.render('profile/lineManager', request, response, {
+					confirm: lineManager.confirm,
+					email: lineManager.email,
+					errors,
+					originalUrl: request.body.originalUrl,
+				})
+			)
 			return
 		}
-		const res: any = await registry.checkLineManager({lineManager: lineManager.email}, request.user.accessToken)
+		const res: any = await registry.checkLineManager(
+			{lineManager: lineManager.email},
+			request.user.accessToken
+		)
 		if (res.status === 404) {
-			errors.push("errors.lineManagerMissing")
+			errors.push('errors.lineManagerMissing')
 
-			response.send(template.render('profile/lineManager', request, response, {
-				confirm: lineManager.confirm,
-				email: lineManager.email,
-				errors,
-				originalUrl: request.body.originalUrl,
-			}))
+			response.send(
+				template.render('profile/lineManager', request, response, {
+					confirm: lineManager.confirm,
+					email: lineManager.email,
+					errors,
+					originalUrl: request.body.originalUrl,
+				})
+			)
 			return
 		} else if (res.status === 400) {
 			errors.push('errors.lineManagerIsUser')
 
-			response.send(template.render('profile/lineManager', request, response, {
-				confirm: lineManager.confirm,
-				email: lineManager.email,
-				errors,
-				originalUrl: request.body.originalUrl,
-			}))
+			response.send(
+				template.render('profile/lineManager', request, response, {
+					confirm: lineManager.confirm,
+					email: lineManager.email,
+					errors,
+					originalUrl: request.body.originalUrl,
+				})
+			)
 			return
 		} else if (res.status === 200) {
 			setLocalProfile(request, 'lineManager', {email: lineManager.email})
@@ -393,7 +481,11 @@ export async function updateLineManager(request: Request, response: Response) {
 	}
 
 	request.session!.save(() =>
-			response.redirect((request.body.originalUrl !== "undefined") ? request.body.originalUrl : defaultRedirectUrl)
+		response.redirect(
+			request.body.originalUrl !== 'undefined'
+				? request.body.originalUrl
+				: defaultRedirectUrl
+		)
 	)
 }
 
@@ -402,29 +494,51 @@ export function addEmail(request: Request, response: Response) {
 	response.send(template.render('profile/email', request, response))
 }
 
-export async function updateEmail(request: Request, response: Response) {
+export async function updateEmail(
+	request: Request,
+	response: Response,
+	next: NextFunction
+) {
 	try {
-		const email = request.user.userName
-		const oldDomain = email.split("@")[1]
-		await identity.isWhitelisted(request.user.accessToken, oldDomain)
-			.then(async e => {
-				if (e === false) {
-					await adjustTokenQuota(request, oldDomain)
-				}
-			})
-			.catch(error => {
-				logger.error(error)
-				throw new Error(error)
-			})
+		const agencyTokenFactory: AgencyTokenFactory = new AgencyTokenFactory()
+		const user = request.user
+		const email = user.userName
+		const oldDomain = email.split('@')[1]
+		if (
+			_.isEmpty(user.organisationalUnit) ||
+			user.organisationalUnit === undefined ||
+			user.organisationalUnit.code === undefined
+		) {
+			logger.debug(
+				`User ${
+					user.id
+				} does not have org code. Cannot validate, so sending them to change email form`
+			)
+			return request.session!.save(() =>
+				response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
+			)
+		}
+
+		const value: any = await registry.getAgencyTokenForUser(user, user.organisationalUnit.code, oldDomain)
+		if (value.status === 404) {
+			logger.debug(`User ${user.id} does not agency token. Sending them to change email form`)
+			return response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
+		}
+		const agencyToken = agencyTokenFactory.create(value.data)
+		await adjustTokenQuota(user, agencyToken, oldDomain)
 		const dto = {forceOrgChange: true}
-		const res: any = await registry.updateForceOrgResetFlag(request.user.accessToken, dto)
+		const res: any = await registry.updateForceOrgResetFlag(user, dto)
 		if (res.status === 204) {
 			setLocalProfile(request, 'department', null)
 			setLocalProfile(request, 'organisationalUnit', null)
 			setLocalProfile(request, 'forceOrgChange', true)
-			logger.info('Org updated, redirecting to ' + config.AUTHENTICATION.serviceUrl + '/account/email')
+			logger.info(
+				'Org updated, redirecting to ' +
+					config.AUTHENTICATION.serviceUrl +
+					'/account/email'
+			)
 
-			request.session!.save(() =>
+			return request.session!.save(() =>
 				response.redirect(config.AUTHENTICATION.serviceUrl + '/account/email')
 			)
 		}
@@ -462,27 +576,30 @@ function setLocalProfile(request: Request, key: string, value: any) {
 	request.session!.passport.user = JSON.stringify(user)
 
 	/* tslint:disable-next-line:no-empty */
-	request.session!.save(() => {
-	})
+	request.session!.save(() => {})
 }
 
-async function adjustTokenQuota(request: Request, oldDomain: string) {
-	// tslint:disable-next-line:max-line-length
-	const oldTokenResponse: any = await registry.getAgencyTokenByDomainAndOrgCode(request.user.accessToken, oldDomain, request.user.organisationalUnit.code)
-	if (oldTokenResponse.status === 404) {
-		console.log("token not found")
-		throw new Error("token not found")
-	} else {
-		const oldToken: string = oldTokenResponse.data.token
-		const quotaDTO = {domain: oldDomain, token: oldToken, code:  request.user.organisationalUnit.code, removeUser: true}
-		registry.updateAvailableSpacesOnAgencyToken(request.user.accessToken, quotaDTO)
+async function adjustTokenQuota(
+	user: User,
+	agencyToken: AgencyToken,
+	oldDomain: string
+) {
+	const quotaDTO = {
+		code: user.organisationalUnit!.code,
+		domain: oldDomain,
+		removeUser: true,
+		token: agencyToken.token,
 	}
+	await registry.updateAvailableSpacesOnAgencyToken(user.accessToken, quotaDTO)
 }
 
 class LineManagerForm {
-	@IsEmail({}, {
-		message: 'profile.lineManager.email.invalid',
-	})
+	@IsEmail(
+		{},
+		{
+			message: 'profile.lineManager.email.invalid',
+		}
+	)
 	@IsNotEmpty({
 		message: 'profile.lineManager.email.empty',
 	})
@@ -495,7 +612,7 @@ class LineManagerForm {
 	/* tslint:disable-next-line:variable-name */
 	private readonly _confirm: string
 
-	constructor(data: { email: string, confirm: string }) {
+	constructor(data: {email: string; confirm: string}) {
 		this._email = data.email
 		this._confirm = data.confirm
 	}
@@ -509,21 +626,22 @@ class LineManagerForm {
 	}
 
 	isPresent() {
-		return (this._email || this._confirm)
+		return this._email || this._confirm
 	}
 
 	async validate() {
 		const errors = await validate(this)
 		/*tslint:disable*/
-		const messages = _.flatten(errors.map(error => {
-			return Object.values(error.constraints)
-		}))
+		const messages = _.flatten(
+			errors.map(error => {
+				return Object.values(error.constraints)
+			})
+		)
 		/*tslint:enable*/
 		if (this._email !== this._confirm) {
-			messages.push("profile.lineManager.confirm.match")
+			messages.push('profile.lineManager.confirm.match')
 		}
 
 		return messages
 	}
-
 }

--- a/src/ui/controllers/profile.ts
+++ b/src/ui/controllers/profile.ts
@@ -136,7 +136,6 @@ export async function updateOrganisation(request: Request, response: Response) {
 		setLocalProfile(request, 'department', organisationalUnit.code)
 		setLocalProfile(request, 'organisationalUnit', organisationalUnit)
 		setLocalProfile(request, 'forceOrgChange', new ForceOrgChange(false))
-		logger.info(request.user)
 		request.session!.save(() =>
 			response.redirect(request.body.originalUrl ? request.body.originalUrl : defaultRedirectUrl)
 		)

--- a/src/ui/controllers/user.ts
+++ b/src/ui/controllers/user.ts
@@ -381,9 +381,11 @@ export async function renderEditPage(
 			const email = req.user.userName
 			const domain = email.split("@")[1]
 			response = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
-			response.data.map((x: any) => {
-				options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
-			})
+			if (response.data !== "") {
+				response.data.map((x: any) => {
+					options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
+				})
+			}
 			optionType = OptionTypes.Typeahead
 			value = req.user.department
 			break

--- a/src/ui/controllers/user.ts
+++ b/src/ui/controllers/user.ts
@@ -78,18 +78,11 @@ const http = axios.create({
 axiosLogger.axiosRequestLogger(http, logger)
 axiosLogger.axiosResponseLogger(http, logger)
 
-function renderSignIn(
-	req: express.Request,
-	res: express.Response,
-	props: SignIn
-) {
+function renderSignIn(req: express.Request, res: express.Response, props: SignIn) {
 	return template.render('account/sign-in', req, res, props)
 }
 
-async function updateUserObject(
-	req: express.Request,
-	updatedProfile: Record<string, string>
-) {
+async function updateUserObject(req: express.Request, updatedProfile: Record<string, string>) {
 	const newUser = model.User.create({
 		...req.user,
 		...updatedProfile,
@@ -162,10 +155,7 @@ export function haltoObject(traversonResult: any[]): {} {
 	return out
 }
 
-export async function renderEditPage(
-	req: express.Request,
-	res: express.Response
-) {
+export async function renderEditPage(req: express.Request, res: express.Response) {
 	const inputName = req.params.profileDetail
 	let options: {[prop: string]: any} = {}
 	let optionType: string = ''
@@ -195,11 +185,9 @@ export async function renderEditPage(
 				options['/professions/' + x.id] = x.name
 			})
 			if (req.user.otherAreasOfWork) {
-				value = req.user.otherAreasOfWork.map(
-					(otherAreasOfWork: {name: string}) => {
-						return otherAreasOfWork.name
-					}
-				)
+				value = req.user.otherAreasOfWork.map((otherAreasOfWork: {name: string}) => {
+					return otherAreasOfWork.name
+				})
 			}
 
 			optionType = OptionTypes.Checkbox
@@ -208,13 +196,10 @@ export async function renderEditPage(
 		case 'department':
 			const email = req.user.userName
 			const domain = email.split('@')[1]
-			response = await registry.getWithoutHal(
-				'/organisationalUnits/flat/' + domain + '/'
-			)
+			response = await registry.getWithoutHal('/organisationalUnits/flat/' + domain + '/')
 			if (response.data !== '') {
 				response.data.map((x: any) => {
-					options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] =
-						x.formattedName
+					options[x.href.replace(config.REGISTRY_SERVICE_URL, '')] = x.formattedName
 				})
 				value = req.user.department
 			}
@@ -279,19 +264,10 @@ export function signIn(req: express.Request, res: express.Response) {
 }
 
 export async function signOut(req: express.Request, res: express.Response) {
-	await passport.logout(
-		config.AUTHENTICATION.serviceUrl,
-		config.LPG_UI_SERVER,
-		req,
-		res,
-		req.user.accessToken
-	)
+	await passport.logout(config.AUTHENTICATION.serviceUrl, config.LPG_UI_SERVER, req, res, req.user.accessToken)
 }
 
-export async function tryUpdateProfile(
-	req: express.Request,
-	res: express.Response
-) {
+export async function tryUpdateProfile(req: express.Request, res: express.Response) {
 	const validFields = validateForm(req)
 
 	if (req.body['primary-area-of-work']) {
@@ -386,10 +362,7 @@ export async function patchAndUpdate(
 	}
 }
 
-export async function updateProfile(
-	ireq: express.Request,
-	res: express.Response
-) {
+export async function updateProfile(ireq: express.Request, res: express.Response) {
 	const req = ireq as extended.CourseRequest
 
 	let inputName = req.params.profileDetail

--- a/src/ui/factory/agencyTokenFactory.ts
+++ b/src/ui/factory/agencyTokenFactory.ts
@@ -1,0 +1,13 @@
+import {AgencyToken} from "../model/agencyToken"
+
+export class AgencyTokenFactory {
+	public create(data: any): any {
+		const agencyToken: AgencyToken = new AgencyToken()
+
+		agencyToken.token = data.token
+		agencyToken.capacityUsed = data.capacityUsed
+		agencyToken.capacity = data.capacity
+
+		return agencyToken
+	}
+}

--- a/src/ui/model/agencyToken.ts
+++ b/src/ui/model/agencyToken.ts
@@ -1,0 +1,7 @@
+export class AgencyToken {
+	token: string
+
+	capacity: number
+
+	capacityUsed: number
+}

--- a/src/ui/page/profile/email.html
+++ b/src/ui/page/profile/email.html
@@ -1,5 +1,6 @@
 <Page title="Confirm Change of Email" {_csrf}>
     <div class="container">
+        <a href="/profile" class="link-back">Back</a>
         <h1 class="heading-large">
             <span class="heading-primary">Confirm change of email</span>
         </h1>


### PR DESCRIPTION
Refactoring change your email flow. If a user doesn't have an organisation, we should just send the user to the change email form because we cant check whether they are an agency token user. 

Furthermore, this was only handling users that were either Whitelisted or Agency tokens, but this did not handle users who had been invited via IDM. Updating logic accordingly.

Adding model and factory classes for agency token objects.

Lots of prettier formatting updates.