### PR TITLE
LC-190: accessibility update for search page

### DIFF
--- a/src/ui/assets/styles/components/_leftSearchBox.scss
+++ b/src/ui/assets/styles/components/_leftSearchBox.scss
@@ -54,6 +54,10 @@
 .hide-filters {
 	position: absolute;
 	left: -9999px;
+
+	@include media(641px) {
+		display: none;
+	}
 }
 
 .filter-label {

--- a/src/ui/component/LeftSearchBox.html
+++ b/src/ui/component/LeftSearchBox.html
@@ -1,6 +1,6 @@
 <aside role="complementary">
     <input type="checkbox" id="hide-filter" class="hide-filters" aria-hidden="true"/>
-    <label class="filter-label"for="hide-filter">search filters</label>
+    <label class="filter-label" for="hide-filter">search filters</label>
     <form class="filter-form" autocomplete="off" name="searchLearning" method="get" action="/search">
         <input type="hidden" id="query" name="q" value="{ query }" />
         <button type="submit" class="button">Apply search filters</button>

--- a/src/ui/component/LeftSearchBox.html
+++ b/src/ui/component/LeftSearchBox.html
@@ -1,5 +1,5 @@
 <aside role="complementary">
-    <input type="checkbox" id="hide-filter" class="hide-filters" aria-hidden="true"/>
+    <input type="checkbox" id="hide-filter" class="hide-filters"/>
     <label class="filter-label" for="hide-filter">search filters</label>
     <form class="filter-form" autocomplete="off" name="searchLearning" method="get" action="/search">
         <input type="hidden" id="query" name="q" value="{ query }" />

--- a/src/ui/component/LeftSearchBox.html
+++ b/src/ui/component/LeftSearchBox.html
@@ -1,4 +1,6 @@
 <aside role="complementary">
+    <input type="checkbox" id="hide-filter" class="hide-filters" aria-hidden="true"/>
+    <label class="filter-label"for="hide-filter">search filters</label>
     <form class="filter-form" autocomplete="off" name="searchLearning" method="get" action="/search">
         <input type="hidden" id="query" name="q" value="{ query }" />
         <button type="submit" class="button">Apply search filters</button>


### PR DESCRIPTION
On mobile view, the search page will show a hide/show search filters checkbox, not visible during standard desktop view. Adding an aria-hidden = "true" to the element so that it is not narrated by screen readers.