### PR TITLE
LC 883 - removed reference to cshr.digital in CORS/csp configurations

### DIFF
--- a/src/lib/config/corsConfig.ts
+++ b/src/lib/config/corsConfig.ts
@@ -1,19 +1,7 @@
-import * as config from "lib/config/index"
-
 export function setCorsOptions() {
-	let corsOptions = {}
-	if (config.PROFILE === 'prod') {
-		corsOptions = {
-			allowedHeaders: ['Authorization', 'Content-Type', 'X-Experience-API-Version'],
-			credentials: true,
-			origin: /\.civilservice\.gov\.uk$/,
-		}
-	} else {
-		corsOptions = {
-			allowedHeaders: ['Authorization', 'Content-Type', 'X-Experience-API-Version'],
-			credentials: true,
-			origin: /\.cshr\.digital$/,
-		}
+	return {
+		allowedHeaders: ['Authorization', 'Content-Type', 'X-Experience-API-Version'],
+		credentials: true,
+		origin: /\.civilservice\.gov\.uk$/,
 	}
-	return corsOptions
 }

--- a/src/lib/config/luscaConfig.ts
+++ b/src/lib/config/luscaConfig.ts
@@ -5,7 +5,7 @@ export function setCspPolicy(staticAssetDomain: string) {
 	if (config.PROFILE === 'prod') {
 		contentCdn = 'https://cdn.learn.civilservice.gov.uk'
 	} else {
-		contentCdn = `https://${config.PROFILE}-cdn.cshr.digital`
+		contentCdn = `https://cdn.${config.PROFILE}.learn.civilservice.gov.uk`
 	}
 
 	let staticCdn: string


### PR DESCRIPTION
- Normalised CORS functionality as it longer needs to differentiate between .cshr.digital/.civilservice.gov.uk
- Updated lusca config to cope with new test env URLs