### PR TITLE
LC-1072 Audiences fix

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -529,7 +529,7 @@ export class Audience {
 		if (user.department && this.departments.indexOf(user.department) > -1) {
 			relevance += 1 // N.B. user.areasOfWork!.indexOf(areaOfWork) will be false for index 0 , so check for > -1
 		}
-		if (user.grade && this.grades.indexOf(user.grade) > -1) {
+		if (user.grade && this.grades.indexOf(user.grade.code) > -1) {
 			relevance += 1
 		}
 		return relevance


### PR DESCRIPTION
- getRelevance function now correctly uses the user's grade *code* to compare for relevance, rather than the entire object