### PR TITLE
Add notifications for archived courses

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -382,5 +382,9 @@
 	"line-manager": "line-manager",
 	"other-areas-of-work": "other-areas-of-work",
 	"Commercial": "Commercial",
-	"profile_primary-area-of-work": "profile_primary-area-of-work"
+	"profile_primary-area-of-work": "profile_primary-area-of-work",
+	"archivedWarning": {
+		"heading": "This course has been archived and is no longer available.",
+		"description": "It may appear in your record of completed learning, but cannot be started or resumed."
+	}
 }

--- a/src/ui/assets/styles/components/_notification.scss
+++ b/src/ui/assets/styles/components/_notification.scss
@@ -1,0 +1,19 @@
+.lpg-notification{
+    border: 5px solid #1d70b8;
+
+    .lpg-notification--heading{
+        background-color: #1d70b8;
+        color: white;
+        font-size: 2rem;
+    }
+
+    .lpg-notification--description{
+        font-size: 2.5rem;
+    }
+
+    .lpg-notification--heading,
+    .lpg-notification--description{
+        padding: 20px;
+        font-weight: bold;
+    }
+} 

--- a/src/ui/assets/styles/main.scss
+++ b/src/ui/assets/styles/main.scss
@@ -37,8 +37,8 @@
 @import 'components/pagination';
 @import 'components/tabs';
 @import 'components/levels';
-
 @import 'components/videojs';
+@import 'components/notification';
 
 .phase-banner {
 	@extend %site-width-container;

--- a/src/ui/component/ArchivedWarning.html
+++ b/src/ui/component/ArchivedWarning.html
@@ -1,0 +1,4 @@
+<div class="lpg-notification">
+    <h2 class="lpg-notification--heading">{$i18n('archivedWarning.heading')}</h2>
+    <div class="lpg-notification--description">{$i18n('archivedWarning.description')}</div>
+</div>

--- a/src/ui/page/course/blended.html
+++ b/src/ui/page/course/blended.html
@@ -3,6 +3,9 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {course.title}
         </h1>
@@ -16,18 +19,20 @@
                 <div>{@html $toHtml(course.learningOutcomes)}</div>
                 {/if}
 
-                <div class="discite" id="modules">
-                    {#if course.getMandatoryCount()>0}
-                        <p>
-                            <strong>You must complete { (modules.length ===course.getMandatoryCount($signedInUser)) ? 'all' : ''} {course.getMandatoryCount($signedInUser)} learning modules to finish this topic.</strong>
-                        </p>
-                    {/if}
-                    {#each modules as module}
-                        {#if course.getMandatoryCount() > 0}
-                            <DisciteModule type="blended" {recordState} {course} {module}/>
+                {#if course.status !== "Archived"}
+                    <div class="discite" id="modules">
+                        {#if course.getMandatoryCount()>0}
+                            <p>
+                                <strong>You must complete { (modules.length ===course.getMandatoryCount($signedInUser)) ? 'all' : ''} {course.getMandatoryCount($signedInUser)} learning modules to finish this topic.</strong>
+                            </p>
                         {/if}
-                    {/each}
-                </div>
+                        {#each modules as module}
+                            {#if course.getMandatoryCount() > 0}
+                                <DisciteModule type="blended" {recordState} {course} {module}/>
+                            {/if}
+                        {/each}
+                    </div>
+                {/if}
             </div>
 
             <div class="column-one-third">
@@ -43,6 +48,8 @@
 	import Page from '../../component/Page.html'
     import DisciteModule from '../../component/DisciteModule.html'
     import RightBox from '../../component/Rightbox.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
+
 
 	export default {
 		data() {
@@ -53,7 +60,8 @@
 		components: {
 			Page,
 			DisciteModule,
-			RightBox
+			RightBox,
+            ArchivedWarning
 		}
 	}
 </script>

--- a/src/ui/page/course/display-video.html
+++ b/src/ui/page/course/display-video.html
@@ -4,6 +4,9 @@
 		<p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+		{#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {module.title || course.title}
         </h1>
@@ -44,6 +47,8 @@
 
 <script>
 	import Page from '../../component/Page.html'
+	import ArchivedWarning from '../../component/ArchivedWarning.html'
+
 
 	export default {
 		data() {
@@ -53,6 +58,7 @@
 
 		components: {
 			Page,
+			ArchivedWarning
 		}
 	}
 </script>

--- a/src/ui/page/course/elearning.html
+++ b/src/ui/page/course/elearning.html
@@ -3,6 +3,9 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {module.title || course.title}
         </h1>
@@ -16,7 +19,9 @@
                 <div>{@html $toHtml(course.learningOutcomes)}</div>
                 {/if}
 
-                <a class="button" href="/courses/{course.id}/{module.id}">Start this learning</a>
+                {#if course.status !== "Archived"}
+                    <a class="button" href="/courses/{course.id}/{module.id}">Start this learning</a>
+                {/if}
             </div>
             <div class="column-one-third">
                 {#if courseDetails.length} {#each courseDetails as dataRows}
@@ -30,6 +35,7 @@
 <script>
 	import Page from '../../component/Page.html'
     import Rightbox from '../../component/Rightbox.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
 
 	export default {
 		data() {
@@ -39,7 +45,8 @@
 
 		components: {
 			Page,
-			Rightbox
+			Rightbox,
+            ArchivedWarning
 		}
 	}
 </script>

--- a/src/ui/page/course/face-to-face.html
+++ b/src/ui/page/course/face-to-face.html
@@ -3,6 +3,9 @@
     <p class="no-margin">
         <a class="link-back" href="/suggestions-for-you">Find another course</a>
     </p>
+    {#if course.status === "Archived"}
+        <ArchivedWarning />
+    {/if}
     <h1 class="heading-xlarge heading heading--page-heading ">
         {module.title || course.title}
     </h1>
@@ -33,23 +36,25 @@
         </div>
     {/if}
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
-            {#if canPayByPO}
-                <div class="notice push-bottom">
-                  <i class="icon icon-important">
-                    <span class="visually-hidden">Warning</span>
-                  </i>
-                  <strong class="bold-small">
-                    By proceeding, you are confirming you have gained approval to book this course and have a purchase
-                    order number.
-                  </strong>
-                </div>
-                <HowToGetPo/>
-            {/if}
-            <a class="button" href="/book/{course.id}/{module.id}/choose-date">View availability</a>
+    {#if course.status !== "Archived"}
+        <div class="grid-row">
+            <div class="column-two-thirds">
+                {#if canPayByPO}
+                    <div class="notice push-bottom">
+                    <i class="icon icon-important">
+                        <span class="visually-hidden">Warning</span>
+                    </i>
+                    <strong class="bold-small">
+                        By proceeding, you are confirming you have gained approval to book this course and have a purchase
+                        order number.
+                    </strong>
+                    </div>
+                    <HowToGetPo/>
+                {/if}
+                <a class="button" href="/book/{course.id}/{module.id}/choose-date">View availability</a>
+            </div>
         </div>
-    </div>
+    {/if}
 </div>
 
 </Page>
@@ -58,6 +63,7 @@
 	import Page from '../../component/Page.html'
     import Rightbox from '../../component/Rightbox.html'
     import HowToGetPo from '../../component/statics/Hidden-howtogetpo.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
 
 	export default {
 		data() {
@@ -68,7 +74,8 @@
 		components: {
 			Page,
 			Rightbox,
-			HowToGetPo
+			HowToGetPo,
+            ArchivedWarning
 		}
 	}
 </script>

--- a/src/ui/page/course/file.html
+++ b/src/ui/page/course/file.html
@@ -3,6 +3,9 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {module.title || course.title}
         </h1>
@@ -15,9 +18,12 @@
                 <h2 class="heading-medium">Learning outcomes</h2>
                 <div>{@html $toHtml(course.learningOutcomes)}</div>
                 {/if}
-                <h3 class="heading-small">Download document</h3>
-                <a download href="/courses/{course.id}/{module.id}">{$fileHelpers.fileName(module.url)}</a>
-                ({$fileHelpers.extension(module.url)}, {$fileHelpers.appropriateFileSize(module.fileSize)})
+
+                {#if course.status !== "Archived"}
+                    <h3 class="heading-small">Download document</h3>
+                    <a download href="/courses/{course.id}/{module.id}">{$fileHelpers.fileName(module.url)}</a>
+                    ({$fileHelpers.extension(module.url)}, {$fileHelpers.appropriateFileSize(module.fileSize)})
+                {/if}
             </div>
             <div class="column-one-third">
                 {#if courseDetails.length} {#each courseDetails as dataRows}
@@ -31,6 +37,8 @@
 <script>
 	import Page from '../../component/Page.html'
     import RightBox from '../../component/Rightbox.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
+
 
 	export default {
 		data() {
@@ -40,7 +48,8 @@
 
 		components: {
 			Page,
-			RightBox
+			RightBox,
+            ArchivedWarning
 		}
 	}
 </script>

--- a/src/ui/page/course/link.html
+++ b/src/ui/page/course/link.html
@@ -3,6 +3,9 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {module.title || course.title}
         </h1>
@@ -15,7 +18,10 @@
                 <h2 class="heading-medium">Learning outcomes</h2>
                 <div>{@html $toHtml(course.learningOutcomes)}</div>
                 {/if}
-                <DisciteModule type="single" {course} {module} {recordState}/>
+                {#if course.status !== "Archived"}
+                    <DisciteModule type="single" {course} {module} {recordState}/>
+                {/if}
+                
             </div>
             <div class="column-one-third">
                 {#if courseDetails.length} {#each courseDetails as dataRows}
@@ -30,6 +36,8 @@
     import Page from '../../component/Page.html'
     import DisciteModule from '../../component/DisciteModule.html'
     import RightBox from '../../component/Rightbox.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
+
 
     export default {
         data() {
@@ -40,7 +48,8 @@
         components: {
             Page,
             DisciteModule,
-            RightBox
+            RightBox,
+            ArchivedWarning
         }
     }
 </script>

--- a/src/ui/page/course/noModuleCourse.html
+++ b/src/ui/page/course/noModuleCourse.html
@@ -3,6 +3,9 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {course.title}
         </h1>
@@ -25,6 +28,8 @@
 
 <script>
     import Page from '../../component/Page.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
+
 
     export default {
         data() {
@@ -34,6 +39,7 @@
 
         components: {
             Page,
+            ArchivedWarning
         }
     }
 </script>

--- a/src/ui/page/course/video.html
+++ b/src/ui/page/course/video.html
@@ -3,6 +3,10 @@
         <p class="no-margin">
             <a class="link-back" href="/suggestions-for-you">Find another course</a>
         </p>
+
+        {#if course.status === "Archived"}
+            <ArchivedWarning />
+        {/if}
         <h1 class="heading-xlarge heading heading--page-heading ">
             {module.title || course.title}
         </h1>
@@ -14,7 +18,10 @@
                 <h2 class="heading-medium">Learning outcomes</h2>
                 <div>{@html $toHtml(course.learningOutcomes)}</div>
                 {/if}
-                <DisciteModule type="single" {course} {module} {recordState}/>
+
+                {#if course.status !== "Archived"}
+                    <DisciteModule type="single" {course} {module} {recordState}/>
+                {/if}
             </div>
             <div class="column-one-third">
                 {#if courseDetails.length} {#each courseDetails as dataRows}
@@ -28,6 +35,8 @@
     import Page from '../../component/Page.html'
     import DisciteModule from '../../component/DisciteModule.html'
     import RightBox from '../../component/Rightbox.html'
+    import ArchivedWarning from '../../component/ArchivedWarning.html'
+
     export default {
         data() {
             return {
@@ -36,7 +45,8 @@
         components: {
             Page,
             DisciteModule,
-            RightBox
+            RightBox,
+            ArchivedWarning
         }
     }
 </script>


### PR DESCRIPTION
This change:

* Creates a Svelte component `ArchivedWarning`
* Creates a `SCSS` styling for `ArchivedWarning`
* Adds entries for archived warning text on internationalisation files
* Adds warnings to course pages if a course is archived (see screenshots)
* Removes interactions from course pages if a course is archived (see screenshots)

## Screenshots

### A "Published" (non-archived course)

* No warning
* Interactions are visible

<img width="1295" alt="" src="https://user-images.githubusercontent.com/97103826/153246366-8fa7f140-df83-42ef-bbe1-db433e5b4953.png">

### An archived course

* Archived warning visible
* Interactions hidden

<img width="1295" alt="" src="https://user-images.githubusercontent.com/97103826/153246577-5fe21cdb-46ce-4e10-a558-0617ec7af63f.png">

## Changes by course type

### Face to face

Removes:

* Approval warning
* "How to get a PO number" link
* "View availability" button

### eLearning

Removes the "Start this learning" button

### Video / link / file

Removes the "Start" link
