### PR TITLE
Updated wording of error messages

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -382,5 +382,10 @@
 	"line-manager": "line-manager",
 	"other-areas-of-work": "other-areas-of-work",
 	"Commercial": "Commercial",
-	"profile_primary-area-of-work": "profile_primary-area-of-work"
+	"profile_primary-area-of-work": "profile_primary-area-of-work",
+	"serviceError": {
+		"sorryThereIsAProblem": "Sorry, there is a problem with this service",
+		"somethingHasGoneWrong": "Something has gone wrong with the system. We're looking into it.",
+		"pleaseSignOut": "Please <a href='/sign-out'>sign out</a> and try again."
+	}
 }

--- a/src/ui/page/booking/ouch.html
+++ b/src/ui/page/booking/ouch.html
@@ -3,9 +3,11 @@
         <div class="grid-row">
             
             <div class="column-two-thirds">
-                <h1 class="heading-xlarge">Ouch</h1>
-                <p class="lede">Something went horribly wrong while booking. Please contact <a href="mailto:csldigital-support@cslearning.gov.uk">csldigital-support@cslearning.gov.uk</a>.</p>
-            </div>
+                <h1 class="heading-xlarge">{ $i18n('serviceError.sorryThereIsAProblem') }</h1>
+                <p class="lede">Something has gone wrong with the system. Please contact <a href="mailto:csldigital-support@cslearning.gov.uk">csldigital-support@cslearning.gov.uk</a>. We're looking into it.</p>
+				<p class="generic-error">{@html $toHtml($i18n('serviceError.pleaseSignOut'))}</p>
+
+			</div>
         </div>
     </div>
 </Page>

--- a/src/ui/page/error.html
+++ b/src/ui/page/error.html
@@ -1117,15 +1117,14 @@
         <div class="container">
             <div class="grid-row">
                 <div class="column-two-thirds">
-                    <h1 class="heading-xlarge">Ouch</h1>
+                    <h1 class="heading-xlarge">{ $i18n('serviceError.sorryThereIsAProblem') }</h1>
 
                     {#if isNonProd}
                     <p id="error-time">{errorTime}</p>
                     <p id="error-stack">{error}</p>
                     {:else}
-                    <p id="generic-error" class="lede">Something went horribly wrong. But don't worry, we're looking into it.</p>
-                    <p class="generic-error">Please <a href="/sign-out">log-out</a> and try again.</p>
-                    <p id="error-message">Please wait a few minutes and try again.</p>
+                    <p id="generic-error" class="lede">{$i18n('serviceError.somethingHasGoneWrong')}</p>
+                    <p class="generic-error">{@html $toHtml($i18n('serviceError.pleaseSignOut'))}</p>
                     {/if}
                 </div>
             </div>


### PR DESCRIPTION
This change updates the wording of the error (previously "Ouch").

## Integration test:

After stopping Learner Record:

![Screenshot 2022-03-23 at 13 39 26](https://user-images.githubusercontent.com/97103826/159712827-5869ea2a-77d0-40c0-8781-338648ae27f2.png)

