### PR TITLE
Update Crown Copyright link

### DIFF
--- a/src/ui/component/Footer.html
+++ b/src/ui/component/Footer.html
@@ -43,7 +43,7 @@
 				</div>
 			</div>
 			<div class="copyright">
-				<a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">
+				<a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
 					© Crown copyright
 				</a>
 			</div>

--- a/src/ui/page/error.html
+++ b/src/ui/page/error.html
@@ -1141,7 +1141,7 @@
                 </div>
             </div>
             <div class="copyright">
-                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
             </div>
         </div>
     </div>

--- a/src/ui/page/error/404.html
+++ b/src/ui/page/error/404.html
@@ -1138,7 +1138,7 @@
                 </div>
             </div>
             <div class="copyright">
-                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This change updates the "Crown copyright" footer link to the correct address