### PR TITLE
LC 1716 manage learne record API calls

### DIFF
--- a/src/lib/config/featureConfig.ts
+++ b/src/lib/config/featureConfig.ts
@@ -1,2 +1,0 @@
-
-export const DB = {PERSIST_ELEARNING_EXPERIENCED_STATEMENTS: false}

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -100,6 +100,7 @@ export async function displayModule(
 
 		switch (module.type) {
 			case 'elearning':
+				await new InitialiseActionWorker(course, req.user, module).applyActionToLearnerRecord()
 				res.redirect(
 					`${module.url}/${module.startPage}?title=${encodeURIComponent(module.title) ||
 					encodeURIComponent(course.title)}` +
@@ -113,7 +114,6 @@ export async function displayModule(
 				break
 			case 'link':
 			case 'file':
-				logger.debug("STARTING")
 				await new CompletedActionWorker(course, req.user, module).applyActionToLearnerRecord()
 				res.redirect(module.url!)
 				break

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -63,15 +63,14 @@ export async function proxy(ireq: express.Request, res: express.Response) {
 		}
 	}
 
-	const xapiBody = Array.isArray(body) ? body[0] : body
-
 	// If the request is a statement request, sync the verb(s) to learner record and then throw away the request.
 	// Learning locker doesn't use the statements.
 	// Also, only sync COMPLETED, PASSED and FAILED verbs. IN_PROGRESS status can be set at module launch.
 	if (req.path === '/statements') {
-		await Promise.all(body.map((b: any) => {
+		const xapiBody = Array.isArray(body) ? body : [body]
+		await Promise.all(xapiBody.map((b: any) => {
 			if (b.verb && b.verb.id && learnerRecordVerbs.includes(b.verb.id)) {
-				syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, xapiBody.verb.id)
+				syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
 			}
 		}))
 		return res.sendStatus(200)

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -21,12 +21,8 @@ import {
 const logger = getLogger('controllers/xapi')
 
 const learnerRecordVerbs = [
-	xapi.Verb.Attempted,
 	xapi.Verb.Completed,
-	xapi.Verb.Experienced,
 	xapi.Verb.Failed,
-	xapi.Verb.Initialised,
-	xapi.Verb.Launched,
 	xapi.Verb.Passed,
 ]
 

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import * as express from 'express'
 import * as config from 'lib/config'
-import * as extended from 'lib/extended'
 import { getLogger } from 'lib/logger'
 import * as xapi from 'lib/xapi'
 import * as querystring from 'querystring'
@@ -26,8 +25,7 @@ const learnerRecordVerbs = [
 	xapi.Verb.Passed,
 ]
 
-export async function proxy(ireq: express.Request, res: express.Response) {
-	let req = ireq as extended.CourseRequest
+export async function proxy(req: express.Request, res: express.Response) {
 	logger.debug(`Proxying xAPI request to ${req.path}`)
 
 	const user = req.user
@@ -124,7 +122,7 @@ export async function proxy(ireq: express.Request, res: express.Response) {
 	}
 }
 
-async function unwrapPost(req: extended.CourseRequest) {
+async function unwrapPost(req: express.Request) {
 	// @ts-ignore
 	req.method = req.query.method
 	const data = querystring.parse(req.body)
@@ -147,7 +145,7 @@ async function unwrapPost(req: extended.CourseRequest) {
 	return req
 }
 
-function updateStatement(statement: any, agent: any, req: extended.CourseRequest) {
+function updateStatement(statement: any, agent: any, req: express.Request) {
 	if (statement.actor) {
 		statement.actor = agent
 	}

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -55,7 +55,13 @@ export async function proxy(req: express.Request, res: express.Response) {
 			const xapiBody = Array.isArray(body) ? body : [body]
 			await Promise.all(xapiBody.map((b: any) => {
 				if (b.verb && b.verb.id && learnerRecordVerbs.includes(b.verb.id)) {
-					syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
+					try {
+						syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
+					} catch (e) {
+						console.error(`Error syncing data to learner record: ${e}. CourseID: ${req.params.proxyCourseId}.
+						ModuleID: ${req.params.proxyModuleId}. User: ${user.id}. Verb: ${b.verb.id}`)
+						res.sendStatus(500)
+					}
 				}
 			}))
 		}

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -59,7 +59,7 @@ export async function proxy(req: express.Request, res: express.Response) {
 						return syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
 					}
 				} catch (e) {
-					console.error(`Error syncing data to learner record: ${e}. CourseID: ${req.params.proxyCourseId}.
+					logger.error(`Error syncing data to learner record: ${e}. CourseID: ${req.params.proxyCourseId}.
 					ModuleID: ${req.params.proxyModuleId}. User: ${user.id}. Verb: ${b.verb.id}`)
 				}
 			}))

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -30,6 +30,15 @@ export async function proxy(ireq: express.Request, res: express.Response) {
 	let req = ireq as extended.CourseRequest
 	logger.debug(`Proxying xAPI request to ${req.path}`)
 
+	const user = req.user
+
+	if (user === undefined) {
+		logger.error(`User in xAPI request was undefined. CourseID: ${req.params.proxyCourseId}.
+						ModuleID: ${req.params.proxyModuleId}. Returning 500 to avoid an exception`)
+		logger.debug(JSON.stringify(req.cookies))
+		return res.sendStatus(500)
+	}
+
 	if (req.query.method) {
 		// This indicates a request has been converted to a POST. The request body will contain headers and parameter
 		// required for actually completing the request.

--- a/src/ui/controllers/xapi.ts
+++ b/src/ui/controllers/xapi.ts
@@ -54,14 +54,13 @@ export async function proxy(req: express.Request, res: express.Response) {
 		if (body) {
 			const xapiBody = Array.isArray(body) ? body : [body]
 			await Promise.all(xapiBody.map((b: any) => {
-				if (b.verb && b.verb.id && learnerRecordVerbs.includes(b.verb.id)) {
-					try {
-						syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
-					} catch (e) {
-						console.error(`Error syncing data to learner record: ${e}. CourseID: ${req.params.proxyCourseId}.
-						ModuleID: ${req.params.proxyModuleId}. User: ${user.id}. Verb: ${b.verb.id}`)
-						res.sendStatus(500)
+				try {
+					if (b.verb && b.verb.id && learnerRecordVerbs.includes(b.verb.id)) {
+						return syncToLearnerRecord(req.params.proxyCourseId, req.params.proxyModuleId, req.user, b.verb.id)
 					}
+				} catch (e) {
+					console.error(`Error syncing data to learner record: ${e}. CourseID: ${req.params.proxyCourseId}.
+					ModuleID: ${req.params.proxyModuleId}. User: ${user.id}. Verb: ${b.verb.id}`)
 				}
 			}))
 		}


### PR DESCRIPTION
- Prevent statements from going to learning locker
- Only update E-Learning on launch and COMPLETED verb
- Check if user is undefined and return if so, preventing the exception that occurs
- Wrap the learner record sync in a try catch to prevent container crashes