### PR TITLE
LC 2102 homepage extra module fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"sass": "gulp sass",
 		"start:all": "npm run start:ui",
 		"start:build": "npm run build && npm run start:ui",
+		"start:ts": "npm run compile && npm run start:ui",
 		"start:ui": "cd dist/ui && node --icu-data-dir=../../node_modules/full-icu ../node_modules/ui/server.js",
 		"test:ts": "npm run test-single:ts \"src/**/*.spec.ts\"",
 		"test-single:ts": "cross-env NODE_ICU_DATA=node_modules/full-icu ts-mocha --paths -p ./tsconfig.json --timeout 10000 --exit",

--- a/src/lib/learnerrecord.ts
+++ b/src/lib/learnerrecord.ts
@@ -7,7 +7,6 @@ import {getPurchaseOrder} from "lib/service/skills"
 import * as query from 'querystring'
 import * as config from './config'
 import * as model from './model'
-import * as catalog from './service/catalog'
 
 export enum CourseState {
 	Completed = 'COMPLETED',
@@ -132,19 +131,6 @@ export async function getRecord(
 		return convert(record)
 	}
 	return null
-}
-
-export async function getLearningRecord(
-	user: model.User, activityIds?: string[], includeStates?: string[], ignoreStates?: string[])
-	: Promise<model.Course[]> {
-	const records = await getRawLearningRecord(user, activityIds, includeStates, ignoreStates)
-	const courseIds = records.map(record => record.courseId)
-	const courses = await catalog.list(courseIds, user)
-
-	for (const course of courses) {
-		course.record = records.find(r => r.courseId === course.id)
-	}
-	return courses
 }
 
 export async function getRawLearningRecord(

--- a/src/lib/learnerrecord.ts
+++ b/src/lib/learnerrecord.ts
@@ -228,7 +228,6 @@ export interface CourseRcd {
 	preference?: string
 	state?: string | undefined
 	lastUpdated?: Date
-	courseDisplayState?: string
 
 	isComplete(): boolean
 	getSelectedDate(): Date | undefined
@@ -245,7 +244,6 @@ export class CourseRecord implements CourseRcd {
 	preference?: string
 	state?: string | undefined
 	lastUpdated?: Date
-	courseDisplayState?: string
 
 	constructor(data: any) {
 		this.courseId = data.courseId

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -188,7 +188,7 @@ export class Course {
 	audiences: Audience[]
 	audience?: Audience
 
-	record?: learnerRecord.CourseRecord
+	record?: learnerRecord.CourseRcd
 
 	constructor(id: string) {
 		this.id = id

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -431,6 +431,10 @@ export class Course {
 		}
 		return module
 	}
+
+	hasModules() {
+		return (this.modules || []).length > 0
+	}
 }
 
 export class CourseModule {

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -312,7 +312,7 @@ export class Course {
 			if (bookedModuleRecord) {
 				const bookedModule = this.modules.find(m => m.id === bookedModuleRecord.moduleId)
 				if (bookedModule) {
-					const event = bookedModule.events.find(event => event.id === bookedModuleRecord.eventId!)
+					const event = bookedModule.getEvent(bookedModuleRecord.eventId!)
 					if (event) {
 						return event.startDate
 					}
@@ -328,7 +328,7 @@ export class Course {
 			if (bookedModuleRecord) {
 				const bookedModule = this.modules.find(m => m.id === bookedModuleRecord.moduleId)
 				if (bookedModule) {
-					const event = bookedModule.events.find(event => event.id === bookedModuleRecord.eventId!)
+					const event = bookedModule.getEvent(bookedModuleRecord.eventId!)
 					if (event) {
 						return event.dateRanges.sort(function compare(a, b) {
 							const dateA = new Date(_.get(a, 'date', ''))
@@ -539,6 +539,10 @@ export class Module {
 			return '0 minutes'
 		}
 		return datetime.formatCourseDuration(this.duration)
+	}
+
+	getEvent(eventId: string) {
+		return this.events.find(event => event.id === eventId)
 	}
 
 	isAssociatedLearning() {

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -312,7 +312,7 @@ export class Course {
 			if (bookedModuleRecord) {
 				const bookedModule = this.modules.find(m => m.id === bookedModuleRecord.moduleId)
 				if (bookedModule) {
-					const event = bookedModule.getEvent(bookedModuleRecord.eventId!)
+					const event = bookedModule.events.find(event => event.id === bookedModuleRecord.eventId!)
 					if (event) {
 						return event.startDate
 					}
@@ -328,7 +328,7 @@ export class Course {
 			if (bookedModuleRecord) {
 				const bookedModule = this.modules.find(m => m.id === bookedModuleRecord.moduleId)
 				if (bookedModule) {
-					const event = bookedModule.getEvent(bookedModuleRecord.eventId!)
+					const event = bookedModule.events.find(event => event.id === bookedModuleRecord.eventId!)
 					if (event) {
 						return event.dateRanges.sort(function compare(a, b) {
 							const dateA = new Date(_.get(a, 'date', ''))
@@ -539,10 +539,6 @@ export class Module {
 			return '0 minutes'
 		}
 		return datetime.formatCourseDuration(this.duration)
-	}
-
-	getEvent(eventId: string) {
-		return this.events.find(event => event.id === eventId)
 	}
 
 	isAssociatedLearning() {

--- a/src/lib/service/catalog/courseCatalogueClient.ts
+++ b/src/lib/service/catalog/courseCatalogueClient.ts
@@ -1,5 +1,6 @@
 import { plainToClass } from 'class-transformer'
-import { User } from '../../model'
+
+import { Course, User } from '../../model'
 import { client } from './config'
 import { GetCoursesParams, GetCoursesResponse } from './models/getCoursesParams'
 
@@ -14,6 +15,17 @@ export async function getCourses(getCoursesParams: GetCoursesParams, user: User)
 		user
 	)
 	return plainToClass(GetCoursesResponse, resp)
+}
+
+export async function getCoursesWithIds(ids: string[], user: User) {
+	const resp = await client._post<string[], Course[]>(
+		{
+			url: `${URL}/getIds`,
+		},
+		ids,
+		user
+	)
+	return resp.map(c => plainToClass(Course, c))
 }
 
 export async function getCoursesV2(getCoursesParams: GetCoursesParams, user: User) {

--- a/src/lib/service/catalog/courseCatalogueClient.ts
+++ b/src/lib/service/catalog/courseCatalogueClient.ts
@@ -25,7 +25,7 @@ export async function getCoursesWithIds(ids: string[], user: User) {
 		ids,
 		user
 	)
-	return resp.map(c => plainToClass(Course, c))
+	return resp.map(c => Course.create(c, user))
 }
 
 export async function getCoursesV2(getCoursesParams: GetCoursesParams, user: User) {

--- a/src/lib/service/catalog/index.ts
+++ b/src/lib/service/catalog/index.ts
@@ -5,6 +5,7 @@ import * as config from 'lib/config'
 import { getLogger } from 'lib/logger'
 import * as model from 'lib/model'
 import * as api from 'lib/service/catalog/api'
+import * as courseCatalogueClient from './courseCatalogueClient'
 
 const logger = getLogger('catalog')
 
@@ -152,19 +153,7 @@ export async function get(id: string, user: model.User, departmentHierarchyCodes
 }
 
 export async function list(ids: string[], user: model.User) {
-	if (ids.length === 0) {
-		return []
-	}
-	try {
-		const response = await http.post(`/courses/getIds`,
-			ids, {headers: {Authorization: `Bearer ${user.accessToken}`}})
-		return response.data.map((r: any) => model.Course.create(r, user))
-	} catch (e) {
-		if (e.response && e.response.status === 404) {
-			return null
-		}
-		throw new Error(`Error getting course - ${e}`)
-	}
+	return await courseCatalogueClient.getCoursesWithIds(ids, user)
 }
 
 async function convertNew(data: any, user?: model.User, usersOrganisationHierarchy?: string[]) {

--- a/src/lib/service/learnerRecordAPI/courseRecord/client.ts
+++ b/src/lib/service/learnerRecordAPI/courseRecord/client.ts
@@ -4,7 +4,6 @@ import { getLogger } from 'lib/logger'
 import * as model from '../../../model'
 import { JsonPatch } from '../../shared/models/JsonPatch'
 import { client } from '../baseConfig'
-import { ModuleRecord } from '../moduleRecord/models/moduleRecord'
 import { CourseRecord, CourseRecordResponse } from './models/courseRecord'
 import { CourseRecordInput } from './models/courseRecordInput'
 
@@ -47,7 +46,7 @@ export async function getFullRecord(user: model.User): Promise<CourseRecord[]> {
 		url: URL,
 	}, user)
 	const courseRecords = plainToClass(CourseRecordResponse, resp)
-	return await Promise.all(courseRecords.courseRecords.map(buildCourseRecord))
+	return await Promise.all(courseRecords.courseRecords.map(c => plainToClass(CourseRecord, c)))
 }
 
 export async function getCourseRecord(courseId: string, user: model.User): Promise<CourseRecord|undefined> {
@@ -65,16 +64,10 @@ export async function getCourseRecord(courseId: string, user: model.User): Promi
 	const courseRecords = plainToClass(CourseRecordResponse, resp).courseRecords
 	let courseRecord
 	if (courseRecords.length === 1) {
-		courseRecord = buildCourseRecord(courseRecords[0])
+		courseRecord = plainToClass(CourseRecord, courseRecords[0])
 	} else if (courseRecords.length > 1) {
 		logger.warn(`Course record for course ID ${courseId} and user ID ${user.id} returned a result set greater than 1`)
-		courseRecord = buildCourseRecord(courseRecords[0])
+		courseRecord = plainToClass(CourseRecord, courseRecords[0])
 	}
-	return courseRecord
-}
-
-async function buildCourseRecord(courseRecordData: CourseRecord) {
-	const courseRecord = plainToClass(CourseRecord, courseRecordData)
-	courseRecord.modules = courseRecordData.modules = courseRecordData.modules.map(m => plainToClass(ModuleRecord, m))
 	return courseRecord
 }

--- a/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
+++ b/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
@@ -26,7 +26,6 @@ export class CourseRecord extends Record implements CourseRcd {
 	preference?: CourseRecordPreference
 	@Type(() => Date)
 	lastUpdated?: Date
-	courseDisplayState?: string
 	required: boolean
 
 	constructor(

--- a/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
+++ b/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
@@ -4,7 +4,7 @@ import * as datetime from 'lib/datetime'
 import { CourseRcd } from '../../../../learnerrecord'
 import { Module } from '../../../../model'
 import { Record, RecordState } from '../../models/record'
-import { BookingStatus, ModuleRecord } from '../../moduleRecord/models/moduleRecord'
+import { ModuleRecord } from '../../moduleRecord/models/moduleRecord'
 
 export enum CourseRecordPreference {
 	Liked = 'LIKED',
@@ -75,22 +75,6 @@ export class CourseRecord extends Record implements CourseRcd {
 			!this.isSkipped() &&
 			!this.isDisliked()
 		)
-	}
-
-	public setBookingStatus(bookingStatus?: BookingStatus) {
-		switch (bookingStatus) {
-			case BookingStatus.CANCELLED:
-				this.state = RecordState.Cancelled
-				break
-			case BookingStatus.REQUESTED:
-				this.state = RecordState.Requested
-				break
-			case BookingStatus.CONFIRMED:
-				this.state = RecordState.Confirmed
-				break
-			default:
-				break
-		}
 	}
 
 	public getSelectedDate() {

--- a/src/lib/service/learnerRecordAPI/models/record.ts
+++ b/src/lib/service/learnerRecordAPI/models/record.ts
@@ -1,3 +1,5 @@
+import { BookingStatus } from "../moduleRecord/models/moduleRecord"
+
 export enum RecordState {
 	Null = '',
 	NotStarted = 'NOT_STARTED',
@@ -9,15 +11,15 @@ export enum RecordState {
 	Registered = 'REGISTERED',
 	Approved = 'APPROVED',
 	Booked = 'BOOKED',
-	Cancelled = 'CANCELLED',
-	Requested = 'REQUESTED',
-	Confirmed = 'CONFIRMED',
+	// Cancelled = 'CANCELLED',
+	// Requested = 'REQUESTED',
+	// Confirmed = 'CONFIRMED',
 }
 
 export class Record {
 	courseId: string
 	userId: string
-	state?: RecordState
+	state?: RecordState | BookingStatus
 
 	constructor(courseId: string, userId: string, state?: RecordState) {
 		this.courseId = courseId

--- a/src/lib/service/learnerRecordAPI/models/record.ts
+++ b/src/lib/service/learnerRecordAPI/models/record.ts
@@ -11,9 +11,6 @@ export enum RecordState {
 	Registered = 'REGISTERED',
 	Approved = 'APPROVED',
 	Booked = 'BOOKED',
-	// Cancelled = 'CANCELLED',
-	// Requested = 'REQUESTED',
-	// Confirmed = 'CONFIRMED',
 }
 
 export class Record {

--- a/src/lib/service/learnerRecordAPI/models/record.ts
+++ b/src/lib/service/learnerRecordAPI/models/record.ts
@@ -9,6 +9,9 @@ export enum RecordState {
 	Registered = 'REGISTERED',
 	Approved = 'APPROVED',
 	Booked = 'BOOKED',
+	Cancelled = 'CANCELLED',
+	Requested = 'REQUESTED',
+	Confirmed = 'CONFIRMED',
 }
 
 export class Record {

--- a/src/lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord.ts
+++ b/src/lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord.ts
@@ -1,4 +1,6 @@
-import {Record, RecordState} from '../../models/record'
+import { Type } from 'class-transformer'
+
+import { Record, RecordState } from '../../models/record'
 
 export enum ModuleRecordResult {
 	Failed = 'FAILED',
@@ -13,8 +15,10 @@ export enum BookingStatus {
 
 export class ModuleRecord extends Record {
 	id: number
+	@Type(() => Date)
 	completionDate?: Date
 	eventId?: string
+	@Type(() => Date)
 	eventDate?: Date
 	moduleId: string
 	moduleTitle: string
@@ -24,7 +28,9 @@ export class ModuleRecord extends Record {
 	duration?: number
 	rated?: boolean
 	bookingStatus?: BookingStatus
+	@Type(() => Date)
 	createdAt?: Date
+	@Type(() => Date)
 	updatedAt?: Date
 	result?: ModuleRecordResult
 

--- a/src/ui/controllers/home.ts
+++ b/src/ui/controllers/home.ts
@@ -14,7 +14,9 @@ import { getDisplayStateForCourse } from './learning-record'
 
 const logger = getLogger('controllers/home')
 
-export const getRequiredLearning = (requiredCourses: model.Course[], courseRecordMap: Map<string, CourseRecord>): model.Course[] => {
+export const getRequiredLearning = (
+	requiredCourses: model.Course[],
+	courseRecordMap: Map<string, CourseRecord>): model.Course[] => {
 	const requiredLearning: model.Course[] = []
 	for (const requiredCourse of requiredCourses) {
 		const courseRecord = courseRecordMap.get(requiredCourse.id)
@@ -23,7 +25,6 @@ export const getRequiredLearning = (requiredCourses: model.Course[], courseRecor
 			if (state !== RecordState.Completed) {
 				if (state !== RecordState.Null) {
 					courseRecord.state = state
-					courseRecord.courseDisplayState = state
 				}
 				requiredCourse.record = courseRecord
 				requiredLearning.push(requiredCourse)
@@ -36,14 +37,13 @@ export const getRequiredLearning = (requiredCourses: model.Course[], courseRecor
 	return requiredLearning
 }
 
-export const getLearningPlanRecords = async (courseRecordMap: Map<string, CourseRecord>): Promise<CourseRecord[]> => {
+export const getLearningPlanRecords = (courseRecordMap: Map<string, CourseRecord>): CourseRecord[] => {
 	const bookedLearning: CourseRecord[] = []
 	const plannedLearning: CourseRecord[] = []
 	courseRecordMap.forEach((record: CourseRecord) => {
 		if (!record.isComplete() && record.isActive()) {
 			if (!record.state && (record.modules || []).length) {
 				record.state = RecordState.InProgress
-				record.courseDisplayState = RecordState.InProgress
 			}
 			if (record.getSelectedDate()) {
 				const bookedModuleRecord = record.modules.find(m => !!m.eventId)
@@ -78,8 +78,8 @@ export async function home(req: express.Request, res: express.Response, next: ex
 		)
 		const requiredLearning = getRequiredLearning(requiredLearningResults.results, courseRecordMap)
 		requiredLearning.forEach(course => courseRecordMap.delete(course.id))
-		
-		const plannedLearningRecords = await getLearningPlanRecords(courseRecordMap)
+
+		const plannedLearningRecords = getLearningPlanRecords(courseRecordMap)
 		const plannedLearning = []
 		if (plannedLearningRecords.length > 0) {
 			const learningPlanCourseIds = plannedLearningRecords.map(cr => cr.courseId)

--- a/src/ui/controllers/home.ts
+++ b/src/ui/controllers/home.ts
@@ -29,19 +29,15 @@ export async function home(req: express.Request, res: express.Response, next: ex
 		learningRecord.map(cr => courseRecordMap.set(cr.courseId, cr))
 
 		for (const requiredCourse of requiredCourses) {
-			console.log("\n======")
-			console.log(requiredCourse.id)
 			const courseRecord = courseRecordMap.get(requiredCourse.id)
 			if (courseRecord) {
 				const state = getDisplayStateForCourse(requiredCourse, courseRecord)
 				if (state !== RecordState.Completed) {
-					console.log(state)
 					if (state !== RecordState.Null) {
 						courseRecord.state = state
 						courseRecord.courseDisplayState = state
 					}
 					requiredCourse.record = courseRecord
-					console.log(requiredCourse)
 					requiredLearning.push(requiredCourse)
 				}
 			} else {

--- a/src/ui/controllers/home.ts
+++ b/src/ui/controllers/home.ts
@@ -77,8 +77,7 @@ export async function home(req: express.Request, res: express.Response, next: ex
 			learningRecord.map((cr): [string, CourseRecord] => [cr.courseId, cr])
 		)
 		const requiredLearning = getRequiredLearning(requiredLearningResults.results, courseRecordMap)
-		requiredLearning.forEach(course => courseRecordMap.delete(course.id))
-
+		
 		const plannedLearningRecords = getLearningPlanRecords(courseRecordMap)
 		const plannedLearning = []
 		if (plannedLearningRecords.length > 0) {

--- a/src/ui/controllers/home.ts
+++ b/src/ui/controllers/home.ts
@@ -48,7 +48,7 @@ export const getLearningPlanRecords = (courseRecordMap: Map<string, CourseRecord
 			if (record.getSelectedDate()) {
 				const bookedModuleRecord = record.modules.find(m => !!m.eventId)
 				if (bookedModuleRecord) {
-					record.setBookingStatus(bookedModuleRecord.bookingStatus)
+					record.state = bookedModuleRecord.bookingStatus
 				}
 				bookedLearning.push(record)
 			} else {
@@ -77,7 +77,7 @@ export async function home(req: express.Request, res: express.Response, next: ex
 			learningRecord.map((cr): [string, CourseRecord] => [cr.courseId, cr])
 		)
 		const requiredLearning = getRequiredLearning(requiredLearningResults.results, courseRecordMap)
-		
+
 		const plannedLearningRecords = getLearningPlanRecords(courseRecordMap)
 		const plannedLearning = []
 		if (plannedLearningRecords.length > 0) {

--- a/src/ui/controllers/learning-record/feedback.ts
+++ b/src/ui/controllers/learning-record/feedback.ts
@@ -1,13 +1,12 @@
 import * as express from 'express'
 import * as extended from 'lib/extended'
-import * as learnerRecord from 'lib/learnerrecord'
 import { getLogger } from 'lib/logger'
 import * as catalog from 'lib/service/catalog'
 import * as template from 'lib/ui/template'
 
 import {
 	RateModuleActionWorker
-} from '../../../lib/service/learnerRecordAPI/workers/moduleRecordActionWorkers/RateModuleActionWorker'
+} from 'lib/service/learnerRecordAPI/workers/moduleRecordActionWorkers/RateModuleActionWorker'
 
 const logger = getLogger('controllers/learning-record/feedback')
 
@@ -95,22 +94,4 @@ export async function submitFeedback(
 			res.redirect('/learning-record/feedback')
 		})
 	}
-}
-
-export async function listItemsForFeedback(
-	req: express.Request,
-	res: express.Response
-) {
-	const learningRecord = await learnerRecord.getLearningRecord(req.user)
-	const readyForFeedback = await learnerRecord.getReadyForFeedback(
-		learningRecord
-	)
-
-	res.send(
-		template.render('learning-record/feedback-list', req, res, {
-			readyForFeedback,
-			successMessage: req.flash('successMessage')[0],
-			successTitle: req.flash('successTitle')[0],
-		})
-	)
 }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -271,11 +271,6 @@ app.get('/learning-record',
 )
 
 app.get(
-	'/learning-record/feedback',
-	asyncHandler(learningRecordFeedbackController.listItemsForFeedback)
-)
-
-app.get(
 	'/learning-record/:courseId/:moduleId/feedback',
 	asyncHandler(learningRecordFeedbackController.displayFeedback)
 )


### PR DESCRIPTION
- Fixed homepage logic. Homepage now respects all relevant modules in a course and calculates completion statuses according to learning period. Refactored the `courseRecord` class to achieve this.
- Introduced a `CourseRcd` interface to ensure compatibility with legacy courseRecord and current courseRecord with a long-term aim to move away from the legacy `courseRecord` and `getRawLearnerRecord` code
- Added new `npm` command for running with just the TS compiler