### PR TITLE
LC-2258 suggested learning grade code bug

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -978,6 +978,10 @@ export class User {
 			this.hasRole('KNOWLEDGEPOOL_SUPPLIER_AUTHOR')
 		)
 	}
+
+	getGradeCode() {
+		return this.grade ? this.grade.code : ''
+	}
 }
 
 function sortEvents(events: Event[]) {

--- a/src/lib/service/catalog/suggestedLearning/suggestedLearningService.spec.ts
+++ b/src/lib/service/catalog/suggestedLearning/suggestedLearningService.spec.ts
@@ -7,29 +7,34 @@ import * as courseRecordClient from '../../learnerRecordAPI/courseRecord/client'
 import * as service from './suggestedLearningService'
 import {Suggestion} from './suggestion'
 
-const sampleUser = User.create({
-	grade: {code: '7', name: 'Grade 7'},
-	interests: [{name: 'Commercial'}, {name: 'EU'}],
-	organisationalUnit: {
-		code: 'ORG',
-		id: 123,
-	},
-	otherAreasOfWork: [
-		{id: 2, name: 'Communications'},
-		{id: 3, name: 'DDaT'},
-		{id: 4, name: "I don't know"},
-	],
-	profession: {
-		id: 1,
-		name: 'Analysis',
-	},
-})
-
 const sampleDepartmentCodes = ['ORG', 'ORG-PARENT', 'ORG-GRANDPARENT']
+
+const createSampleUser = () => {
+	return User.create({
+		grade: {code: '7', name: 'Grade 7'},
+		interests: [{name: 'Commercial'}, {name: 'EU'}],
+		organisationalUnit: {
+			code: 'ORG',
+			id: 123,
+		},
+		otherAreasOfWork: [
+			{id: 2, name: 'Communications'},
+			{id: 3, name: 'DDaT'},
+			{id: 4, name: "I don't know"},
+		],
+		profession: {
+			id: 1,
+			name: 'Analysis',
+		},
+	})
+}
+
+let sampleUser = createSampleUser()
 
 describe('suggestedLearningService tests', () => {
 	beforeEach(() => {
 		sinon.reset()
+		sampleUser = createSampleUser()
 	})
 	describe('User detail functions', () => {
 		it('Should test that getAreasOfWorkForUser', () => {
@@ -54,6 +59,20 @@ describe('suggestedLearningService tests', () => {
 				expect(section.params!).to.eql({
 					departments: 'ORG,ORG-PARENT,ORG-GRANDPARENT',
 					grade: '7',
+					page: 0,
+					size: 200,
+				})
+				expect(section.key).to.eql('ORG')
+				expect(section.suggestion).to.eql(Suggestion.DEPARTMENT)
+			})
+
+			it('Should create suggestion parameter for the users department when the user has no grade assigned', () => {
+				sampleUser.grade = undefined
+				const sections = service.createParamsForDepartmentSection(sampleDepartmentCodes, sampleUser)
+				const section = sections[0]
+				expect(section.params!).to.eql({
+					departments: 'ORG,ORG-PARENT,ORG-GRANDPARENT',
+					grade: '',
 					page: 0,
 					size: 200,
 				})

--- a/src/lib/service/catalog/suggestedLearning/suggestedLearningService.ts
+++ b/src/lib/service/catalog/suggestedLearning/suggestedLearningService.ts
@@ -59,7 +59,7 @@ export async function extractSuggestionParams(user: User, departmentHierarchyCod
 export function createParamsForDepartmentSection(departmentCodes: string[], user: User): SuggestionSection[] {
 	const param = {
 		departments: departmentCodes.join(','),
-		grade: user.grade.code,
+		grade: user.getGradeCode(),
 		page: 0,
 		size: DEFAULT_RECORDS_TO_SCAN_IN_ELASTIC,
 	}
@@ -73,7 +73,7 @@ export function createParamsForAreaOfWorkSection(departmentCodes: string[], user
 				? {
 						areaOfWork: aow,
 						excludeDepartments: departmentCodes,
-						grade: user.grade.code,
+						grade: user.getGradeCode(),
 						page: 0,
 						size: DEFAULT_RECORDS_TO_SCAN_IN_ELASTIC,
 				}
@@ -94,7 +94,7 @@ export function createParamsForOtherAreasOfWorkSection(departmentCodes: string[]
 						areaOfWork,
 						excludeAreasOfWork,
 						excludeDepartments: departmentCodes,
-						grade: user.grade.code,
+						grade: user.getGradeCode(),
 						page: 0,
 						size: DEFAULT_RECORDS_TO_SCAN_IN_ELASTIC,
 					}
@@ -111,7 +111,7 @@ export function createParamsForInterestsSection(departmentCodes: string[], user:
 			excludeAreasOfWork,
 			excludeDepartments: departmentCodes,
 			excludeInterests,
-			grade: user.grade.code,
+			grade: user.getGradeCode(),
 			interest,
 			page: 0,
 			size: DEFAULT_RECORDS_TO_SCAN_IN_ELASTIC,


### PR DESCRIPTION
- `getGradeCode` - a new method on the user class which returns an empty string if the user's grade is null
- Suggestions for you now make use of the new above method to calculate suggested learning, even when the grade is null