### PR TITLE
Fix YouTube player issue

### DIFF
--- a/src/ui/assets/js/video.js
+++ b/src/ui/assets/js/video.js
@@ -15,7 +15,7 @@
 	var youTubePlayer = true
 	
 	var detectVideoPlayer = function(){
-		if (document.getElementById("#video-player")) {
+		if (document.getElementById("video-player")) {
 			youTubePlayer = true
 		} else {
 			youTubePlayer = false

--- a/src/ui/assets/js/video.js
+++ b/src/ui/assets/js/video.js
@@ -15,7 +15,7 @@
 	var youTubePlayer = true
 	
 	var detectVideoPlayer = function(){
-		if ($('#video-player').size() !==0) {
+		if (document.getElementById("#video-player")) {
 			youTubePlayer = true
 		} else {
 			youTubePlayer = false


### PR DESCRIPTION
This change replaces the use of jQuery to detect the video player with the basic `document.getElementById` function. The issue arose after updating jQuery to a version after 3.0, which completely removed the `$().size()` function.