### PR TITLE
Remove default on profile switch statement

### DIFF
--- a/src/ui/controllers/user.ts
+++ b/src/ui/controllers/user.ts
@@ -221,8 +221,6 @@ export async function renderEditPage(req: express.Request, res: express.Response
 				return interest.name
 			})
 			break
-		default:
-			return res.redirect('/profile')
 	}
 
 	res.send(


### PR DESCRIPTION
Line manager (`line-manager` param) fails the case statement and defaults to redirecting to `/profile` - include a case statement for line manager that unfortunately does nothing.

Profile endpoints should be split out to separate,defined functions in the future to avoid strange behaviour.