### PR TITLE
LC-2882 fix homepage in progress status

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -1,12 +1,14 @@
 import {Type} from 'class-transformer'
 import * as datetime from 'lib/datetime'
 import * as learnerRecord from 'lib/learnerrecord'
+import {CourseRecord} from 'lib/service/learnerRecordAPI/courseRecord/models/courseRecord'
+import {RecordState} from 'lib/service/learnerRecordAPI/models/record'
 import {CacheableObject} from 'lib/utils/cacheableObject'
-import _ = require('lodash')
 import * as moment from 'moment'
 import {Duration} from 'moment'
 import 'reflect-metadata'
 
+import _ = require('lodash')
 import {ModuleNotFoundError} from './exception/moduleNotFound'
 
 export interface LineManager {
@@ -233,6 +235,54 @@ export class Course {
 
 	getModules() {
 		return this.modules
+	}
+
+	public getModulesRequiredForCompletion() {
+		const optModules: Module[] = []
+		const requiredModules: Module[] = []
+		this.modules.forEach(m => {
+			m.optional ? optModules.push(m) : requiredModules.push(m)
+		})
+		return requiredModules.length > 0 ? requiredModules : optModules
+	}
+
+	public getDisplayState(courseRecord: CourseRecord): RecordState {
+		const requiredModuleIdsForCompletion = this.getModulesRequiredForCompletion()
+		const displayStateForModules = this.getDisplayStateForModules(courseRecord)
+		let nullCount = 0
+		let completedCount = 0
+		for (const module of requiredModuleIdsForCompletion) {
+			const state = displayStateForModules.get(module.id) || null
+
+			if (state === 'COMPLETED') {
+				completedCount ++
+			} else if (state === null) {
+				nullCount ++
+			}
+		}
+
+		if (completedCount === requiredModuleIdsForCompletion.length) {
+			return RecordState.Completed
+		} else if (nullCount === requiredModuleIdsForCompletion.length) {
+			return RecordState.Null
+		} else {
+			return RecordState.InProgress
+		}
+	}
+
+	public getDisplayStateForModules(courseRecord: CourseRecord): Map<string, string | null> {
+		const results = new Map<string, string | null>()
+		const moduleRecords = courseRecord.getModuleRecordMap()
+		const audience = this.getRequiredRecurringAudience()
+		this.modules.forEach(m => {
+			const moduleRecord = moduleRecords.get(m.id)
+			let state: string | null = moduleRecord === undefined ? null : moduleRecord.getState()
+			if (moduleRecord && audience) {
+				state = moduleRecord.getDisplayState(audience)
+			}
+			results.set(m.id, state)
+		})
+		return results
 	}
 
 	getRequiredModules() {

--- a/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
+++ b/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
@@ -94,6 +94,14 @@ export class CourseRecord extends Record implements CourseRcd {
 		return this.isArchived()
 	}
 
+	public getModuleRecordMap = () => {
+		const results = new Map<string, ModuleRecord>()
+		this.modules.forEach(m => {
+			results.set(m.moduleId, m)
+		})
+		return results
+	}
+
 	public getModuleRecord = (moduleId: string) => {
 		return this.modules.find(m => m.moduleId === moduleId)
 	}
@@ -111,23 +119,6 @@ export class CourseRecord extends Record implements CourseRcd {
 
 	public getLastUpdated() {
 		return this.lastUpdated ? this.lastUpdated : new Date(0)
-	}
-
-	public getCompletionDatesForModules(filterModules?: Module[]) {
-		if (filterModules) {
-			const mrMap: Map<string, ModuleRecord> = new Map()
-			this.modules.forEach(mr => mrMap.set(mr.moduleId, mr))
-			return filterModules.map(mod => {
-				const moduleRecord = mrMap.get(mod.id)
-				if (moduleRecord) {
-					return moduleRecord.getCompletionDate()
-				} else {
-					return new Date(0)
-				}
-			})
-		} else {
-			return this.modules.map(mr => mr.getCompletionDate())
-		}
 	}
 
 	public getCompletionDate() {

--- a/src/lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord.ts
+++ b/src/lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord.ts
@@ -1,4 +1,5 @@
 import { Type } from 'class-transformer'
+import {RequiredRecurringAudience} from 'lib/model'
 
 import { Record, RecordState } from '../../models/record'
 
@@ -71,6 +72,19 @@ export class ModuleRecord extends Record {
 		this.eventDate = eventDate ? new Date(eventDate) : undefined
 		this.cost = cost
 		this.optional = optional
+	}
+
+	getDisplayState(audience: RequiredRecurringAudience | null) {
+		const completionDate = this.getCompletionDate().getTime()
+		const updatedAt = this.getUpdatedAt().getTime()
+		const previousRequiredBy = audience ? audience.previousRequiredBy.getTime() : new Date(0).getTime()
+		if (previousRequiredBy < completionDate) {
+			return 'COMPLETED'
+		} else if (previousRequiredBy < updatedAt) {
+			return 'IN_PROGRESS'
+		} else {
+			return null
+		}
 	}
 
 	getCompletionDate() {

--- a/src/ui/controllers/course/index.spec.ts
+++ b/src/ui/controllers/course/index.spec.ts
@@ -1,15 +1,10 @@
 import {assert} from 'chai'
 import {RequiredRecurringAudience} from 'lib/model'
-import {CourseRecord} from 'lib/service/learnerRecordAPI/courseRecord/models/courseRecord'
 import {RecordState} from 'lib/service/learnerRecordAPI/models/record'
 import {ModuleRecord} from 'lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord'
-import * as controller from './index'
 
-const getBasicCourseRecord = (state: RecordState) => {
-	return new CourseRecord('Test001', '', state, [], '', false)
-}
-const getBasicModuleRecord = (state: RecordState, lastUpdated: Date, completedDate?: Date) => {
-	const moduleRecord = new ModuleRecord(0, "Test002", '', '', new Date(),
+export const getBasicModuleRecord = (moduleId: string, state: RecordState, lastUpdated: Date, completedDate?: Date) => {
+	const moduleRecord = new ModuleRecord(0, moduleId, '', '', new Date(),
 		lastUpdated, '', 'link', state, 0, false, undefined)
 	moduleRecord.completionDate = completedDate
 	return moduleRecord
@@ -22,65 +17,35 @@ describe('getDisplayStateForModule tests', () => {
 	 * Audience with a due by date of 31/03/2020 on a yearly frequency
 	 */
 	const audience = new RequiredRecurringAudience(new Date("2020-03-31"), new Date("2021-03-31"))
-	describe("When the course has not been completed", () => {
-		const courseRecord = getBasicCourseRecord(RecordState.InProgress)
-		it('should set the state to not started (null) when a module is' +
-			'completed during the previous learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.Completed, lastYearDate, lastYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, null)
-		})
-		it('should set the state to not started (null) when a module is' +
-			'in progress during the previous learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.InProgress, lastYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, null)
-		})
-		it('should set the state to IN_PROGRESS when a module is' +
-						'in progress during the current learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.InProgress, thisYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, "IN_PROGRESS")
-		})
-		it('should set the state to COMPLETED when a module is' +
-			'completed during the current learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.Completed, thisYearDate, thisYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, "COMPLETED")
-		})
-	})
 
-	describe("When the course has already been completed", () => {
-		const courseRecord = getBasicCourseRecord(RecordState.Completed)
-		it('should set the state to not started (null) when a module is' +
-			'completed during the previous learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.Completed, lastYearDate, lastYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, null)
-		})
-		it('should set the state to not started (null) when a module is' +
-			'in progress during the previous learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.InProgress, lastYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, null)
-		})
-		it('should set the state to IN_PROGRESS when a module is' +
-			'in progress during the current learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.InProgress, thisYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, "IN_PROGRESS")
-		})
-		it('should set the state to COMPLETED when a module is' +
-			'completed during the current learning year', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.Completed, thisYearDate, thisYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, audience)
-			assert.equal(result, "COMPLETED")
-		})
-		it('should set the state to COMPLETED when a module has been completed on a non-recurring course ', () => {
-			const moduleRecord = getBasicModuleRecord(RecordState.Completed, lastYearDate, lastYearDate)
-			const result = controller.getDisplayStateForModule(moduleRecord, courseRecord, null)
-			assert.equal(result, "COMPLETED")
-		})
+	it('should set the state to not started (null) when a module is' +
+		'completed during the previous learning year', () => {
+		const moduleRecord = getBasicModuleRecord("1", RecordState.Completed, lastYearDate, lastYearDate)
+		const result = moduleRecord.getDisplayState(audience)
+		assert.equal(result, null)
+	})
+	it('should set the state to not started (null) when a module is' +
+		'in progress during the previous learning year', () => {
+		const moduleRecord = getBasicModuleRecord("1", RecordState.InProgress, lastYearDate)
+		const result = moduleRecord.getDisplayState(audience)
+		assert.equal(result, null)
+	})
+	it('should set the state to IN_PROGRESS when a module is' +
+		'in progress during the current learning year', () => {
+		const moduleRecord = getBasicModuleRecord("1", RecordState.InProgress, thisYearDate)
+		const result = moduleRecord.getDisplayState(audience)
+		assert.equal(result, "IN_PROGRESS")
+	})
+	it('should set the state to COMPLETED when a module is' +
+		'completed during the current learning year', () => {
+		const moduleRecord = getBasicModuleRecord("1", RecordState.Completed, thisYearDate, thisYearDate)
+		const result = moduleRecord.getDisplayState(audience)
+		assert.equal(result, "COMPLETED")
+	})
+	it('should set the state to COMPLETED when a module has been completed on a non-recurring course ', () => {
+		const moduleRecord = getBasicModuleRecord("1", RecordState.Completed, lastYearDate, lastYearDate)
+		const result = moduleRecord.getDisplayState(null)
+		assert.equal(result, "COMPLETED")
 	})
 
 })

--- a/src/ui/controllers/course/index.ts
+++ b/src/ui/controllers/course/index.ts
@@ -6,8 +6,6 @@ import * as catalog from 'lib/service/catalog'
 import * as cslServiceClient from 'lib/service/cslService/cslServiceClient'
 import {removeCourseFromLearningPlan} from 'lib/service/cslService/cslServiceClient'
 import * as courseRecordClient from 'lib/service/learnerRecordAPI/courseRecord/client'
-import {CourseRecord} from 'lib/service/learnerRecordAPI/courseRecord/models/courseRecord'
-import {ModuleRecord} from 'lib/service/learnerRecordAPI/moduleRecord/models/moduleRecord'
 import * as template from 'lib/ui/template'
 import * as youtube from 'lib/youtube'
 
@@ -161,8 +159,8 @@ export async function display(ireq: express.Request, res: express.Response) {
 					.forEach(moduleRecord => {
 					const mapEntry = moduleMap.get(moduleRecord.moduleId)
 					if (mapEntry) {
-						mapEntry.state = moduleRecord.state || null
-						mapEntry.displayState = getDisplayStateForModule(moduleRecord, courseRecord, audience)
+						mapEntry.state = moduleRecord.getState()
+						mapEntry.displayState = moduleRecord.getDisplayState(audience)
 					}
 				})
 			}
@@ -201,32 +199,6 @@ export async function display(ireq: express.Request, res: express.Response) {
 			)
 			break
 	}
-}
-
-export function getDisplayStateForModule(
-	moduleRecord: ModuleRecord,
-	courseRecord: CourseRecord,
-	audience: model.RequiredRecurringAudience | null) {
-	let displayStateLocal: string | null = moduleRecord.state ? moduleRecord.state : null
-	if (audience) {
-		const completionDate = moduleRecord.getCompletionDate().getTime()
-		const updatedAt = moduleRecord.getUpdatedAt().getTime()
-		const previousRequiredBy = audience.previousRequiredBy.getTime()
-		if (completionDate <= previousRequiredBy && previousRequiredBy < updatedAt) {
-			displayStateLocal = 'IN_PROGRESS'
-		} else {
-			if (courseRecord.isCompleted()) {
-				if (updatedAt <= previousRequiredBy && completionDate <= previousRequiredBy) {
-					displayStateLocal = null
-				}
-			} else {
-				if (updatedAt <= previousRequiredBy) {
-					displayStateLocal = null
-				}
-			}
-		}
-	}
-	return displayStateLocal
 }
 
 export async function loadCourse(

--- a/src/ui/controllers/home.ts
+++ b/src/ui/controllers/home.ts
@@ -10,7 +10,6 @@ import * as template from 'lib/ui/template'
 
 import { CourseRecord } from '../../lib/service/learnerRecordAPI/courseRecord/models/courseRecord'
 import { RecordState } from '../../lib/service/learnerRecordAPI/models/record'
-import { getDisplayStateForCourse } from './learning-record'
 
 const logger = getLogger('controllers/home')
 
@@ -21,7 +20,7 @@ export const getRequiredLearning = (
 	for (const requiredCourse of requiredCourses) {
 		const courseRecord = courseRecordMap.get(requiredCourse.id)
 		if (courseRecord) {
-			const state = getDisplayStateForCourse(requiredCourse, courseRecord)
+			const state = requiredCourse.getDisplayState(courseRecord)
 			if (state !== RecordState.Completed) {
 				if (state !== RecordState.Null) {
 					courseRecord.state = state


### PR DESCRIPTION
- Move getDisplayState functions into their respective models
- Remove check for `COMPLETED` status on the course record, completion status of a course is now fully dependant on the completion state of the modules
- Correctly take in progress modules into account when calculating course status