### PR TITLE
LC-2961: Update backlink for video modules

### DIFF
--- a/src/ui/page/course/display-video.html
+++ b/src/ui/page/course/display-video.html
@@ -1,6 +1,5 @@
  <Page title="{module.title || course.title}" {_csrf}>
     <div class="container">
-	    <a href="/suggested-learning">
 		<p class="no-margin">
             <a class="link-back" href="/courses/{course.id}">Return to course</a>
         </p>

--- a/src/ui/page/course/display-video.html
+++ b/src/ui/page/course/display-video.html
@@ -2,7 +2,7 @@
     <div class="container">
 	    <a href="/suggested-learning">
 		<p class="no-margin">
-            <a class="link-back" href="/suggestions-for-you">Find another course</a>
+            <a class="link-back" href="/courses/{course.id}">Return to course</a>
         </p>
 		{#if course.status === "Archived"}
             <ArchivedWarning />


### PR DESCRIPTION
This change 

* Updates the back link at the top of the video display page from "Find another course", which takes the user to the "Suggestions for you page", to "Return to course", which takes the user back to the course overview page.
* Removes unused links in the video display page.