### PR TITLE
LC-3009 fix fetch organisation typeahead

### DIFF
--- a/src/lib/service/civilServantRegistry/models/organisationalUnitTypeAhead.ts
+++ b/src/lib/service/civilServantRegistry/models/organisationalUnitTypeAhead.ts
@@ -12,8 +12,6 @@ export class OrganisationalUnitTypeAhead {
 	@Type(() => OrganisationalUnit)
 	public typeahead: OrganisationalUnit[]
 
-	private collator = new Intl.Collator('en', {numeric: true, sensitivity: 'base'})
-
 	constructor(typeahead: OrganisationalUnit[]) {
 		this.typeahead = typeahead
 	}
@@ -36,7 +34,7 @@ export class OrganisationalUnitTypeAhead {
 	}
 
 	sort() {
-		this.typeahead.sort((a, b) => this.collator.compare(a.formattedName, b.formattedName))
+		this.typeahead.sort((a, b) => this.getCollator().compare(a.formattedName, b.formattedName))
 		return this.typeahead
 	}
 
@@ -74,7 +72,7 @@ export class OrganisationalUnitTypeAhead {
 		const agencyOrg = this.getAgencyOrganisationWithDomain(domain, tree)
 		if (agencyOrg !== undefined) {
 			list.push(...agencyOrg.extractAllOrgs())
-			list.sort((a, b) => this.collator.compare(a.formattedName, b.formattedName))
+			list.sort((a, b) => this.getCollator().compare(a.formattedName, b.formattedName))
 		}
 		return list
 	}
@@ -106,5 +104,9 @@ export class OrganisationalUnitTypeAhead {
 			orgMap.set(org.id, org)
 		}
 		return org.formattedName
+	}
+
+	private getCollator() {
+		return new Intl.Collator('en', {numeric: true, sensitivity: 'base'})
 	}
 }


### PR DESCRIPTION
- The collator object was not being serialized correctly when being fetched from the cache. This has been moved to a private function instead