### PR TITLE
LC-3022: Fix bug setting primary area of work as undefined

### DIFF
--- a/src/ui/controllers/profile.ts
+++ b/src/ui/controllers/profile.ts
@@ -205,7 +205,7 @@ export async function updateProfession(request: Request, response: Response) {
 			const professionResponse: any = await registry.getWithoutHal(profession.replace(config.REGISTRY_SERVICE_URL, ''))
 			const data = professionResponse.data
 
-			setLocalProfile(request, 'areasOfWork', [data.id, data.name])
+			setLocalProfile(request, 'areasOfWork', {id: data.id, name: data.name})
 		} catch (error) {
 			logger.error(error)
 			throw new Error(error)


### PR DESCRIPTION
This change gives `areasOfWork` for each user the correct structure after initial profile completion so that it can be read by the Profile page, instead of showing as "undefined".