### PR TITLE
LC 2958 redis cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"helmet": "3.12.0",
 				"i18n": "0.8.3",
 				"jsonwebtoken": "8.5.1",
+				"jwt-decode": "^4.0.0",
 				"lodash": "4.17.19",
 				"lusca": "1.5.2",
 				"mime-types": "2.1.18",
@@ -6982,6 +6983,14 @@
 			"dependencies": {
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/kind-of": {
@@ -18402,6 +18411,11 @@
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
 		},
 		"kind-of": {
 			"version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 		"helmet": "3.12.0",
 		"i18n": "0.8.3",
 		"jsonwebtoken": "8.5.1",
+		"jwt-decode": "^4.0.0",
 		"lodash": "4.17.19",
 		"lusca": "1.5.2",
 		"mime-types": "2.1.18",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -138,15 +138,13 @@ export const CONTACT_NUMBER = env.CONTACT_NUMBER || '020 3640 7985'
 
 export const REDIS = set({
 	host: env.REDIS_HOST || 'localhost',
+	keyPrefix: env.REDIS_KEY_PREFIX || 'csl_frontend',
 	password: env.REDIS_PASSWORD || '',
 	port: +(env.REDIS_PORT || '6379'),
 })
 
 export const ORG_REDIS = set({
 	defaultTTL: +(env.ORG_REDIS_TTL || '604800'),
-	host: env.ORG_REDIS_HOST || 'localhost',
-	password: env.ORG_REDIS_PASSWORD || '',
-	port: +(env.ORG_REDIS_PORT || '6379'),
 })
 
 export const STATIC_ASSET_ROOT = env.STATIC_ASSET_ROOT

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -137,7 +137,7 @@ export const CONTACT_NUMBER = env.CONTACT_NUMBER || '020 3640 7985'
 
 export const REDIS = set({
 	host: env.REDIS_HOST || 'localhost',
-	keyPrefix: env.REDIS_KEY_PREFIX || 'csl_frontend',
+	keyPrefix: env.REDIS_KEY_PREFIX || 'csl_frontend_',
 	password: env.REDIS_PASSWORD || '',
 	port: +(env.REDIS_PORT || '6379'),
 })

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -34,10 +34,9 @@ export const AUTHENTICATION = set({
 	clientId: env.OAUTH_CLIENT_ID || '9fbd4ae2-2db3-44c7-9544-88e80255b56e',
 	clientSecret: env.OAUTH_CLIENT_SECRET || 'test',
 	endpoints: set({
-		authorization: env.OAUTH_AUTHORIZATION_ENDPOINT || '/oauth/authorize',
-		logout: env.AUTHENTICATION_SERVICE_LOGOUT_ENDPOINT || '/oauth/logout',
-		resolve: env.AUTHENTICATION_SERVICE_RESOLVE_ENDPOINT || '/oauth/resolve',
-		token: env.OAUTH_TOKEN_ENDPOINT || '/oauth/token',
+		authorization: env.OAUTH_AUTHORIZATION_ENDPOINT || '/oauth2/authorize',
+		logout: env.AUTHENTICATION_SERVICE_LOGOUT_ENDPOINT || '/logout',
+		token: env.OAUTH_TOKEN_ENDPOINT || '/oauth2/token',
 	}),
 	managementId: env.OAUTH_CLIENT_ID || 'f90a4080-e5e9-4a80-ace4-f738b4c9c30e',
 	managementSecret: env.OAUTH_CLIENT_SECRET || 'test',

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -24,12 +24,6 @@ export class IdentityDetails {
 	constructor(public username: string, public uid: string, public roles: string[]) { }
 }
 
-export async function getDetails(token: string) {
-	const http = create(token)
-	const response = await http.get<IdentityDetails>(config.AUTHENTICATION.endpoints.resolve)
-	return response.data
-}
-
 export async function logout(token: string) {
 	const http = create(token)
 	const response = await http.get(config.AUTHENTICATION.endpoints.logout)

--- a/src/lib/utils/redis.ts
+++ b/src/lib/utils/redis.ts
@@ -1,0 +1,14 @@
+import * as config from 'lib/config'
+import * as redis from 'redis'
+
+export const client = createRedisClient()
+
+function createRedisClient() {
+	return redis.createClient({
+		auth_pass: config.REDIS.password,
+		host: config.REDIS.host,
+		no_ready_check: true,
+		port: config.REDIS.port,
+		prefix: config.REDIS.keyPrefix,
+	})
+}

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -26,8 +26,8 @@ import {ProfileChecker} from 'lib/ui/profileChecker'
 
 import {requiresDepartmentHierarchy} from 'lib/ui/requiresDepartmentHierarchy'
 import * as template from 'lib/ui/template'
+import {client} from 'lib/utils/redis'
 import * as lusca from 'lusca'
-import * as redis from 'redis'
 import * as serveStatic from 'serve-static'
 import {URL} from 'url'
 import * as bookingRouter from './controllers/booking/routes'
@@ -69,12 +69,6 @@ app.use(cors(corsOptions))
 // Caches
 
 const RedisStore = connectRedis(session)
-const redisClient = redis.createClient({
-	auth_pass: config.REDIS.password,
-	host: config.REDIS.host,
-	no_ready_check: true,
-	port: config.REDIS.port,
-})
 app.use(
 	session({
 		cookie: {
@@ -87,20 +81,13 @@ app.use(
 		saveUninitialized: true,
 		secret: config.SESSION_SECRET,
 		store: new RedisStore({
-			client: redisClient,
+			client,
 		}),
 	})
 )
 
-const orgCacheRedisClient = redis.createClient({
-	auth_pass: config.ORG_REDIS.password,
-	host: config.ORG_REDIS.host,
-	no_ready_check: true,
-	port: config.ORG_REDIS.port,
-})
-
-const orgCache = new OrganisationalUnitCache(orgCacheRedisClient, config.ORG_REDIS.defaultTTL)
-const orgTypeaheadCache = new OrganisationalUnitTypeaheadCache(orgCacheRedisClient, config.ORG_REDIS.defaultTTL)
+const orgCache = new OrganisationalUnitCache(client, config.ORG_REDIS.defaultTTL)
+const orgTypeaheadCache = new OrganisationalUnitTypeaheadCache(client, config.ORG_REDIS.defaultTTL)
 csrsService.setCaches(orgCache, orgTypeaheadCache)
 
 app.use(flash())


### PR DESCRIPTION
- Consolidate both the session and organisation caches into one
- Remove reliance on the old resolve endpoint and make use of the JWT token to fetch the identity details for the user

