### PR TITLE
LC-2633: Navigate users to course overview after leaving a module in progress

### DIFF
--- a/src/ui/controllers/learning-record/index.ts
+++ b/src/ui/controllers/learning-record/index.ts
@@ -31,7 +31,8 @@ export async function courseResult(
 			moduleRecord = courseRecord.modules.find(mr => module.id === mr.moduleId)
 		}
 		if (!moduleRecord || moduleRecord.state !== 'COMPLETED') {
-			res.redirect('/home')
+			console.log("::: Redirecting to /home...")
+			res.redirect(`/courses/${course.id}`)
 		} else {
 			let courseCompleted = true
 			let modulesCompleted = 0

--- a/src/ui/controllers/learning-record/index.ts
+++ b/src/ui/controllers/learning-record/index.ts
@@ -31,7 +31,6 @@ export async function courseResult(
 			moduleRecord = courseRecord.modules.find(mr => module.id === mr.moduleId)
 		}
 		if (!moduleRecord || moduleRecord.state !== 'COMPLETED') {
-			console.log("::: Redirecting to /home...")
 			res.redirect(`/courses/${course.id}`)
 		} else {
 			let courseCompleted = true


### PR DESCRIPTION
This change sets the URL to redirect when a module is still in progress to the course overview page instead of the homepage