### PR TITLE
LC-3215 replace css arrow glyph with hidden tag

### DIFF
--- a/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
+++ b/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
@@ -15,7 +15,6 @@
 					sourceClass = this.getAttribute('class') || ''
 
 				if (targetClass.indexOf('js-visible') !== -1) {
-					console.log(document.getElementsByClassName('menu__icon'))
 					target.setAttribute(
 						'class',
 						targetClass.replace(/(^|\s)js-visible(\s|$)/, ''),

--- a/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
+++ b/src/ui/assets/js/govuk_frontend_toolkit/govuk/govuk-template.js
@@ -15,14 +15,17 @@
 					sourceClass = this.getAttribute('class') || ''
 
 				if (targetClass.indexOf('js-visible') !== -1) {
+					console.log(document.getElementsByClassName('menu__icon'))
 					target.setAttribute(
 						'class',
 						targetClass.replace(/(^|\s)js-visible(\s|$)/, ''),
-						(document.getElementById('visiblyHidden').innerHTML = 'Select to expand')
+						(document.getElementById('visiblyHidden').innerHTML = 'Select to expand'),
 					)
+					document.getElementsByClassName('menu__icon')[0].innerHTML = '▼'
 				} else {
 					target.setAttribute('class', targetClass + ' js-visible')
 					document.getElementById('visiblyHidden').innerHTML = 'Select to close'
+					document.getElementsByClassName('menu__icon')[0].innerHTML = '▲'
 				}
 				if (sourceClass.indexOf('js-hidden') !== -1) {
 					this.setAttribute(

--- a/src/ui/assets/styles/components/_header.scss
+++ b/src/ui/assets/styles/components/_header.scss
@@ -160,17 +160,6 @@ a.menu {
 	&:hover {
 		text-decoration: underline;
 	}
-	&:after {
-		display: inline-block;
-		font-size: 8px;
-		height: 8px;
-		padding-left: 5px;
-		vertical-align: middle;
-		content: ' \25BC';
-	}
-	&.js-hidden:after {
-		content: ' \25B2';
-	}
 }
 #proposition-menu {
 	padding: 10px 0 0 0;
@@ -327,6 +316,14 @@ a.js-header-toggle.menu.js-hidden {
 	@include media(desktop) {
 		display: none;
 	}
+}
+
+.menu__icon {
+	font-size: 8px;
+	height: 8px;
+	padding-left: 2px;
+	vertical-align: middle;
+	display: inline-block;
 }
 
 .phase-tag

--- a/src/ui/component/Header.html
+++ b/src/ui/component/Header.html
@@ -24,7 +24,7 @@
     <p><strong class="phase-tag">BETA</strong> Your <a href="{($req.app.locals.feedbackRoot)}" target="_blank" rel="noopener noreferrer" title="The Civil Service Learning feedback survey will open in another window">feedback</a> will help us to improve.</p>
 </div>
 <div class="content nav-container with-proposition">
-    <a href="#proposition-links" class="js-header-toggle menu"><span class="visually-hidden" id="visiblyHidden">Select to expand</span> Menu</a>
+    <a href="#proposition-links" class="js-header-toggle menu"><span class="visually-hidden" id="visiblyHidden">Select to expand</span> Menu <span aria-hidden='true' class='menu__icon'>▼</span></a>
     <Nav/>
 </div>
 <script>

--- a/src/ui/component/HeaderNoNav.html
+++ b/src/ui/component/HeaderNoNav.html
@@ -12,7 +12,7 @@
         </div>
         <div class="header-proposition">
             <div class="content">
-                <a href="#proposition-links" class="js-header-toggle menu"><span class="visually-hidden" id="visiblyHidden">Select to expand</span> Menu</a>
+                <a href="#proposition-links" class="js-header-toggle menu"><span class="visually-hidden" id="visiblyHidden">Select to expand</span> Menu <span aria-hidden='true' class='menu__icon'>▼</span></a>
                 <a href="/" title="Go to the Learning Platform homepage" id="proposition-name">Civil Service Learning</a>
             </div>
         </div>


### PR DESCRIPTION
- The arrow glyphs used to show when the menu is collapsed/expanded in mobile view are now in a separate span tag which is `aria-hidden`