### PR TITLE
LC-3224 button focus non-text contrast

### DIFF
--- a/views/assets/styles/common/_global.scss
+++ b/views/assets/styles/common/_global.scss
@@ -158,6 +158,20 @@ input:focus, textarea:focus, select:focus, button:focus, .button:focus {
 			cursor: pointer;
 		}
 	}
+	&:focus {
+		outline: 3px solid transparent!important;
+		background: #fd0;
+		color: $black;
+		box-shadow: 0 2px 0 $black;
+		&:hover {
+			outline: 3px solid #fd0!important;
+			box-shadow: none;
+		}
+	}
+	&:hover {
+		background-color: $green;
+		color: $white;
+	}
 }
 
 .button-container {

--- a/views/component/Checkboxes.html
+++ b/views/component/Checkboxes.html
@@ -8,8 +8,8 @@
 {/if}
 	{#each options as option}
         <div class="multiple-choice">
-            <input id="{option.name}" type="checkbox" name="{inputName}" value="{option.id}" checked="{option.checked ? 'checked' : ''}">
-            <label for="{option.name}">{option.name}</label>
+            <input id="{inputName}-{option.id}" type="checkbox" name="{inputName}" value="{option.id}" checked="{option.checked ? 'checked' : ''}">
+            <label for="{inputName}-{option.id}">{option.name}</label>
         </div>
     {/each}
 </fieldset>

--- a/views/component/NewRadios.html
+++ b/views/component/NewRadios.html
@@ -8,8 +8,8 @@
     {/if}
     {#each options as option}
         <div class="multiple-choice">
-            <input id="{option.name}" type="radio" name="{inputName}" value="{option.id}" checked="{option.checked ? 'checked' : ''}">
-            <label for="{option.name}">{option.name}</label>
+            <input id="{inputName}-{option.id}" type="radio" name="{inputName}" value="{option.id}" checked="{option.checked ? 'checked' : ''}">
+            <label for="{inputName}-{option.id}">{option.name}</label>
         </div>
     {/each}
 </fieldset>


### PR DESCRIPTION
- Fix non-text contrast by bringing green CTA button's focus state inline with GDS buttons: https://design-system.service.gov.uk/components/button/
- Fix other accessibility issue where names and ids for profile checkboxes/radios had spaces in