### PR TITLE
Remove reliance on old learner record endpoints

### DIFF
--- a/src/lib/learnerrecord.ts
+++ b/src/lib/learnerrecord.ts
@@ -4,7 +4,6 @@ import * as axiosLogger from './axiosLogger'
 import * as config from './config'
 import * as datetime from './datetime'
 import {getLogger} from './logger'
-import * as model from './model'
 
 const logger = getLogger('learner-record')
 
@@ -41,31 +40,6 @@ export async function getCancellationReasons(user: any): Promise<any> {
 			Authorization: `Bearer ${user.accessToken}`,
 		},
 	})
-}
-
-export async function getRecord(user: model.User, course: model.Course, module?: model.Module, event?: model.Event) {
-	let activityId = course.id
-	if (event) {
-		activityId = event.id
-	} else if (module && !event) {
-		activityId = module.id
-	}
-
-	const response = await http.get(`/records/${user.id}`, {
-		headers: {Authorization: `Bearer ${user.accessToken}`},
-		params: {
-			activityId,
-		},
-	})
-	if (response.data.records.length > 0) {
-		const record = response.data.records[0]
-		return convert(record)
-	}
-	return null
-}
-
-function convert(record: CourseRecord) {
-	return new CourseRecord(record)
 }
 
 export interface CourseRcd {

--- a/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
+++ b/src/lib/service/learnerRecordAPI/courseRecord/models/courseRecord.ts
@@ -150,4 +150,8 @@ export class CourseRecord extends Record implements CourseRcd {
 	private fillRecords = (moduleRecords: ModuleRecord[]) => {
 		this.modules = moduleRecords.map(m => plainToClass(ModuleRecord, m as ModuleRecord))
 	}
+
+	public findEventModuleRecord = (eventId: string) => {
+		return this.modules.find(mr => mr.eventId === eventId)
+	}
 }

--- a/src/ui/controllers/booking/booking.ts
+++ b/src/ui/controllers/booking/booking.ts
@@ -18,22 +18,6 @@ export enum confirmedMessage {
 	Error = 'Error',
 }
 
-export function recordCheck(record: learnerRecord.CourseRecord | null, ireq: express.Request) {
-	const req = ireq as extended.CourseRequest
-
-	if (!record) {
-		logger.warn(
-			`Attempt to cancel a booking when not registered. user: ${req.user.id}, course: ${req.course.id}, module: ${
-				req.module!.id
-			}, event: ${req.event!.id}`
-		)
-
-		return false
-	} else {
-		return true
-	}
-}
-
 export function saveAccessibilityOptions(ireq: express.Request, res: express.Response) {
 	const session = ireq.session!
 	const req = ireq as extended.CourseRequest

--- a/src/ui/controllers/booking/cancel.ts
+++ b/src/ui/controllers/booking/cancel.ts
@@ -2,13 +2,14 @@ import * as express from 'express'
 import {ResourceNotFoundError} from '../../../lib/exception/ResourceNotFoundError'
 import * as extended from '../../../lib/extended'
 import * as learnerRecord from '../../../lib/learnerrecord'
+import * as courseRecordClient from '../../../lib/service/learnerRecordAPI/courseRecord/client'
 import {getLogger} from '../../../lib/logger'
 import {cancelEventBooking} from '../../../lib/service/cslService/cslServiceClient'
 import {CancelBookingDto} from '../../../lib/service/cslService/models/CancelBookingDto'
 import * as template from '../../../lib/ui/template'
 import {SessionFlash} from '../../../lib/utils/SessionUtils'
 
-import {confirmedMessage, recordCheck} from './booking'
+import {confirmedMessage} from './booking'
 
 const logger = getLogger('controllers/booking/cancel')
 
@@ -22,21 +23,15 @@ export async function renderCancelBookingPage(
 	const module = req.module!
 	const event = req.event!
 
-	const record = await learnerRecord.getRecord(req.user, course, module, event)
+	const record = await courseRecordClient.getCourseRecord(course.id, req.user)
+	const moduleRecord = record !== undefined ? record.findEventModuleRecord(event.id) : undefined
 
-	if (!recordCheck(record, ireq)) {
+	if (moduleRecord === undefined) {
 		res.sendStatus(400)
 		return
 	}
 
-	course.record = record!
-
-	const moduleRecord = record!.modules.find(rm => rm.moduleId === module.id && rm.eventId === event.id)
-
-	if (!moduleRecord) {
-		res.sendStatus(400)
-		return
-	}
+	course.record = record
 	;(module as any).record = moduleRecord
 
 	const optionType = 'radio'
@@ -70,24 +65,20 @@ export async function renderCancelledBookingPage(ireq: express.Request, res: exp
 	const event = req.event!
 	let error: string = ''
 
-	const record = await learnerRecord.getRecord(req.user, course, module, event)
+	const record = await courseRecordClient.getCourseRecord(course.id, req.user)
+	const moduleRecord = record !== undefined ? record.findEventModuleRecord(event.id) : undefined
 
-	if (!recordCheck(record, ireq)) {
-		error = req.__('errors.registrationNotFound')
-	} else {
-		const moduleRecord = record!.modules.find(rm => rm.moduleId === module.id && rm.eventId === event.id)
-
-		if (moduleRecord && moduleRecord.state !== 'UNREGISTERED') {
+	if (moduleRecord !== undefined) {
+		if (moduleRecord.state !== 'UNREGISTERED') {
 			req.flash('cancelBookingError', req.__('errors.cancelBooking'))
 			req.session!.save(() => {
 				res.redirect(`/book/${course.id}/${module.id}/${event.id}/cancel`)
 			})
 			return
-		} else if (!moduleRecord) {
-			error = req.__('errors.registrationNotFound')
 		}
+	} else {
+		error = req.__('errors.registrationNotFound')
 	}
-
 	const message = error ? confirmedMessage.Error : confirmedMessage.Cancelled
 
 	res.send(

--- a/src/ui/controllers/learning-record/index.ts
+++ b/src/ui/controllers/learning-record/index.ts
@@ -1,6 +1,5 @@
 import * as express from 'express'
 import * as extended from '../../../lib/extended'
-import * as learnerRecord from '../../../lib/learnerrecord'
 import {getLogger} from '../../../lib/logger'
 import {Course} from '../../../lib/model'
 import * as catalog from '../../../lib/service/catalog'
@@ -19,7 +18,7 @@ export async function courseResult(ireq: express.Request, res: express.Response)
 	try {
 		const course = req.course
 		const module = req.module!
-		const courseRecord = await learnerRecord.getRecord(req.user, course, module)
+		const courseRecord = await courseRecordClient.getCourseRecord(course.id, req.user)
 		let moduleRecord = null
 
 		if (courseRecord && courseRecord.modules) {


### PR DESCRIPTION
- Remove `getRecord`, which relied on the `/records` endpoint. This endpoint has now been removed from the learner record API
- Move logic that relied on `getRecord` over to the `GET /course_records` models