### PR TITLE
LC-3797-Reposition notification banner - LM check should be before no bookable sessions

### DIFF
--- a/views/nunjucks/course/components/moduleCard/macro.njk
+++ b/views/nunjucks/course/components/moduleCard/macro.njk
@@ -57,10 +57,10 @@
     {% else %}
         <div class="discite__action discite__action--module">
             {% if params.type === "face-to-face" %}
-                {% if not params.canBeBooked %}
-                    <span>{{ i18n('components.notification_banner.course_not_bookable') }}</span>
-                {% elseif not signedInUser.lineManager %}
+                {% if not signedInUser.lineManager %}
                     <span>You must <a class="discite__action-link" href='/profile/line-manager?redirectTo={{ originalUrl }}'>add a line manager</a> to book this module</span>
+                {% elseif not params.canBeBooked %}
+                    <span>{{ i18n('components.notification_banner.course_not_bookable') }}</span>
                 {% else %}
                     {{ moduleCardCtaLink(params.launchLink, "action_BOOK", params.title) }}
                 {% endif %}

--- a/views/nunjucks/course/faceToFace.njk
+++ b/views/nunjucks/course/faceToFace.njk
@@ -4,12 +4,11 @@
     {% if pageModel.moduleDetails.cancellationLink %}
         <p>You are already booked on this course. <a href="{{ pageModel.moduleDetails.cancellationLink }}">Do you wish to cancel your booking?</a></p>
     {% else %}
-        {% if not pageModel.moduleDetails.canBeBooked %}
-        {% elseif not signedInUser.hasLineManager() %}
+        {% if not signedInUser.hasLineManager() %}
             <p class='govuk-body'>
                 <span>You must <a class="discite__action-link" href='/profile/line-manager?redirectTo={{ originalUrl }}'>add a line manager</a> to book this course</span>
             </p>
-        {% else %}
+        {% elseif pageModel.moduleDetails.canBeBooked %}
             <div class="notice push-bottom">
                 <i class="icon icon-important">
                     <span class="visually-hidden">Warning</span>

--- a/views/nunjucks/course/layout.njk
+++ b/views/nunjucks/course/layout.njk
@@ -25,7 +25,7 @@
         <h1 id="page-heading" class="heading-xlarge heading heading--page-heading">
             {{ pageModel.title }}
         </h1>
-       {% if (pageModel.type === "face-to-face") and (not pageModel.moduleDetails.cancellationLink) and (not pageModel.moduleDetails.canBeBooked) %}
+       {% if (pageModel.type === "face-to-face") and (signedInUser.hasLineManager()) and (not pageModel.moduleDetails.cancellationLink) and (not pageModel.moduleDetails.canBeBooked) %}
            <div class="grid-row">
                <div class="column-two-thirds">
                    {{ notificationBanner({


### PR DESCRIPTION
Testing Document: https://cshrdigitalandanalysis.atlassian.net/wiki/spaces/LPG/pages/4102946817/LC-3797+Reposition+notification+banner+for+no+bookable+sessions