### PR TITLE
LC-4179 add to learning plan archived courses

### DIFF
--- a/src/ui/controllers/course/models/factory.ts
+++ b/src/ui/controllers/course/models/factory.ts
@@ -111,7 +111,7 @@ export async function getCoursePage(user: User, course: Course): Promise<BasicCo
 		logger.debug(`hasFaceToFaceModule: ${hasFaceToFaceModule}`)
 		if (course.record.isCompleted() || hasFaceToFaceModule) {
 			basicCoursePage.isInLearningPlan = undefined
-		} else basicCoursePage.isInLearningPlan = course.record.state !== 'ARCHIVED';
+		} else basicCoursePage.isInLearningPlan = course.record.state !== 'ARCHIVED'
 	}
 	return basicCoursePage
 }

--- a/src/ui/controllers/course/models/factory.ts
+++ b/src/ui/controllers/course/models/factory.ts
@@ -101,7 +101,7 @@ export async function getCoursePage(user: User, course: Course): Promise<BasicCo
 
 	basicCoursePage.id = course.id
 	basicCoursePage.isInLearningPlan = false
-	if (course.isRequired()) {
+	if (course.isRequired() || course.status === 'Archived') {
 		basicCoursePage.isInLearningPlan = undefined
 	} else if (!course.record) {
 		basicCoursePage.isInLearningPlan = false
@@ -109,11 +109,9 @@ export async function getCoursePage(user: User, course: Course): Promise<BasicCo
 		logger.debug(`course.record.state: ${course.record.state}`)
 		const hasFaceToFaceModule = course.record.modules.some(m => m.moduleType === 'face-to-face')
 		logger.debug(`hasFaceToFaceModule: ${hasFaceToFaceModule}`)
-		if (course.record.isCompleted() || hasFaceToFaceModule || course.record.state === 'ARCHIVED') {
+		if (course.record.isCompleted() || hasFaceToFaceModule) {
 			basicCoursePage.isInLearningPlan = undefined
-		} else {
-			basicCoursePage.isInLearningPlan = true
-		}
+		} else basicCoursePage.isInLearningPlan = course.record.state !== 'ARCHIVED';
 	}
 	return basicCoursePage
 }

--- a/src/ui/controllers/course/models/factory.ts
+++ b/src/ui/controllers/course/models/factory.ts
@@ -109,10 +109,8 @@ export async function getCoursePage(user: User, course: Course): Promise<BasicCo
 		logger.debug(`course.record.state: ${course.record.state}`)
 		const hasFaceToFaceModule = course.record.modules.some(m => m.moduleType === 'face-to-face')
 		logger.debug(`hasFaceToFaceModule: ${hasFaceToFaceModule}`)
-		if (course.record.isCompleted() || hasFaceToFaceModule) {
+		if (course.record.isCompleted() || hasFaceToFaceModule || course.record.state === 'ARCHIVED') {
 			basicCoursePage.isInLearningPlan = undefined
-		} else if (course.record.state === 'ARCHIVED') {
-			basicCoursePage.isInLearningPlan = false
 		} else {
 			basicCoursePage.isInLearningPlan = true
 		}

--- a/views/nunjucks/course/layout.njk
+++ b/views/nunjucks/course/layout.njk
@@ -25,7 +25,7 @@
         <h1 id="page-heading" class="heading-xlarge heading heading--page-heading">
             {{ pageModel.title }}
         </h1>
-       {% if (pageModel.type === "face-to-face") and (signedInUser.hasLineManager()) and (not pageModel.moduleDetails.cancellationLink) and (not pageModel.moduleDetails.canBeBooked) %}
+       {% if (pageModel.type === "face-to-face") and (signedInUser.hasLineManager()) and (not pageModel.moduleDetails.cancellationLink) and (not pageModel.moduleDetails.canBeBooked) and (pageModel.status === 'Published') %}
            <div class="grid-row">
                <div class="column-two-thirds">
                    {{ notificationBanner({


### PR DESCRIPTION
- Hide course actions if the course is archived
- Fix a bug where two info banners are rendered if the course is archived and has no more bookable sessions. Only one banner should ever be displayed at a time